### PR TITLE
M1: Foundations — solution, pipe, VSIX skeleton, ping/vs.status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            9.0.x
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      - name: Restore + Build
+        shell: pwsh
+        run: |
+          msbuild src/VSMCP.sln -t:Restore,Build -p:Configuration=Release -v:minimal -nologo
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: VSMCP.Vsix
+          path: src/VSMCP.Vsix/bin/Release/*.vsix
+          if-no-files-found: error
+
+      - name: Upload VSMCP.Server
+        uses: actions/upload-artifact@v4
+        with:
+          name: VSMCP.Server
+          path: src/VSMCP.Server/bin/Release/**/*
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,13 @@ out/
 *.VC.db
 *.VC.VC.opendb
 
-# VSIX
-*.vsix
-*.pdb
-*.dll
-*.exe
-!**/Properties/**/*.dll
+# VSIX / compiled output (restricted to bin/obj so we don't swallow VSMCP.Vsix/ project dir)
+**/bin/**/*.vsix
+**/bin/**/*.pdb
+**/bin/**/*.dll
+**/bin/**/*.exe
+**/obj/**/*.pdb
+**/obj/**/*.dll
 
 # Rider / ReSharper
 .idea/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <Version>0.1.0</Version>
+    <Authors>pauliver</Authors>
+    <Company>pauliver</Company>
+    <Copyright>Copyright (c) 2026 pauliver</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/pauliver/VSMCP</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+</Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 pauliver
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ See [`DesignDoc.md`](./DesignDoc.md) for architecture, then pick an open milesto
 
 ## License
 
-TBD — likely MIT.
+[MIT](./LICENSE).

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/VSMCP.Server/Program.cs
+++ b/src/VSMCP.Server/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using VSMCP.Server;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// MCP uses stdio; logs must not pollute stdout. Route logs to stderr only.
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
+builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+builder.Services.AddSingleton<VsConnection>();
+
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync();

--- a/src/VSMCP.Server/VSMCP.Server.csproj
+++ b/src/VSMCP.Server/VSMCP.Server.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>VSMCP.Server</RootNamespace>
+    <AssemblyName>vsmcp-server</AssemblyName>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>vsmcp-server</ToolCommandName>
+    <PackageId>VSMCP.Server</PackageId>
+    <Description>Model Context Protocol server that drives Visual Studio 2022. Pairs with the VSMCP VSIX extension.</Description>
+    <PackageTags>mcp;visual-studio;debugger;claude;ai</PackageTags>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\VSMCP.Shared\VSMCP.Shared.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/VSMCP.Server/VsConnection.cs
+++ b/src/VSMCP.Server/VsConnection.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using StreamJsonRpc;
+using VSMCP.Shared;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// Owns the named-pipe connection to a single Visual Studio VSMCP host.
+/// Thread-safe; single instance per process; reconnects on demand.
+/// </summary>
+public sealed class VsConnection : IAsyncDisposable
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private NamedPipeClientStream? _stream;
+    private JsonRpc? _rpc;
+    private IVsmcpRpc? _proxy;
+    private int? _connectedPid;
+
+    public int? ConnectedProcessId => _connectedPid;
+
+    public bool IsConnected => _rpc is { IsDisposed: false } && _stream is { IsConnected: true };
+
+    public async Task<IVsmcpRpc> GetOrConnectAsync(CancellationToken ct)
+    {
+        if (IsConnected && _proxy is not null) return _proxy;
+
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (IsConnected && _proxy is not null) return _proxy;
+
+            var instances = ListInstances();
+            if (instances.Count == 0)
+                throw new InvalidOperationException($"{ErrorCodes.NotConnected}: no running Visual Studio 2022 instance with the VSMCP extension was found. Open VS and ensure the VSMCP extension is installed.");
+
+            if (instances.Count > 1)
+                throw new InvalidOperationException($"{ErrorCodes.NotConnected}: multiple VS instances found ({instances.Count}). Call vs.list_instances and vs.select first.");
+
+            await ConnectToAsync(instances[0].ProcessId, ct).ConfigureAwait(false);
+            return _proxy!;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task ConnectToAsync(int pid, CancellationToken ct)
+    {
+        await DisposeCurrentAsync().ConfigureAwait(false);
+
+        var pipeName = PipeNaming.ForProcess(pid);
+        var stream = new NamedPipeClientStream(".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+        await stream.ConnectAsync(5000, ct).ConfigureAwait(false);
+
+        var rpc = JsonRpc.Attach(stream);
+        var proxy = rpc.Attach<IVsmcpRpc>();
+
+        var hs = await proxy.HandshakeAsync(ProtocolVersion.Major, ProtocolVersion.Minor, ct).ConfigureAwait(false);
+        if (hs.ProtocolMajor != ProtocolVersion.Major)
+        {
+            rpc.Dispose();
+            stream.Dispose();
+            throw new InvalidOperationException(
+                $"{ErrorCodes.UpgradeRequired}: bridge protocol v{ProtocolVersion.DisplayString} is incompatible with extension v{hs.ProtocolMajor}.{hs.ProtocolMinor}. Update both to matching versions.");
+        }
+
+        _stream = stream;
+        _rpc = rpc;
+        _proxy = proxy;
+        _connectedPid = pid;
+    }
+
+    /// <summary>Enumerates VS processes that have a VSMCP pipe listening.</summary>
+    public static IReadOnlyList<VsInstance> ListInstances()
+    {
+        // Windows exposes named pipes at \\.\pipe\. Enumerating this "directory" returns all pipe names.
+        var found = new List<VsInstance>();
+        string[] names;
+        try
+        {
+            names = Directory.GetFiles(@"\\.\pipe\", $"{PipeNaming.Prefix}*");
+        }
+        catch
+        {
+            return found;
+        }
+
+        foreach (var path in names)
+        {
+            var name = Path.GetFileName(path);
+            if (!PipeNaming.IsVsmcpPipe(name)) continue;
+            var pidPart = name.Substring(PipeNaming.Prefix.Length);
+            if (!int.TryParse(pidPart, out var pid)) continue;
+
+            string? title = null;
+            string? solution = null;
+            try
+            {
+                var proc = Process.GetProcessById(pid);
+                title = proc.MainWindowTitle;
+                // Heuristic: VS window title often ends with "— Microsoft Visual Studio" and starts with solution name.
+                if (!string.IsNullOrEmpty(title))
+                {
+                    var dash = title.IndexOf(" - ", StringComparison.Ordinal);
+                    if (dash > 0) solution = title.Substring(0, dash);
+                }
+            }
+            catch { /* process gone */ }
+
+            found.Add(new VsInstance { ProcessId = pid, PipeName = name, MainWindowTitle = title, SolutionPath = solution });
+        }
+
+        return found;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeCurrentAsync().ConfigureAwait(false);
+        _gate.Dispose();
+    }
+
+    private Task DisposeCurrentAsync()
+    {
+        try { _rpc?.Dispose(); } catch { }
+        try { _stream?.Dispose(); } catch { }
+        _rpc = null;
+        _stream = null;
+        _proxy = null;
+        _connectedPid = null;
+        return Task.CompletedTask;
+    }
+}

--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+using VSMCP.Shared;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// MCP tool surface. One method per tool, decorated with <see cref="McpServerToolAttribute"/>.
+/// Connection to VS is lazy; <see cref="VsConnection.GetOrConnectAsync"/> throws
+/// <see cref="ErrorCodes.NotConnected"/> when no instance is reachable.
+/// </summary>
+[McpServerToolType]
+public sealed class VsmcpTools
+{
+    private readonly VsConnection _connection;
+
+    public VsmcpTools(VsConnection connection) => _connection = connection;
+
+    [McpServerTool(Name = "ping")]
+    [Description("Round-trip ping to the connected Visual Studio instance. Returns 'pong' and a server-side timestamp.")]
+    public async Task<PingResult> Ping(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.PingAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "vs.status")]
+    [Description("Summary of the connected Visual Studio: solution path, active configuration, startup project, and debug mode.")]
+    public async Task<VsStatus> VsStatus(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.GetStatusAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "vs.list_instances")]
+    [Description("Enumerate running Visual Studio instances that have the VSMCP extension loaded. Use this when multiple VS windows are open.")]
+    public Task<System.Collections.Generic.IReadOnlyList<VsInstance>> VsListInstances(CancellationToken ct = default)
+        => Task.FromResult(VsConnection.ListInstances());
+
+    [McpServerTool(Name = "vs.select")]
+    [Description("Bind future tool calls to a specific Visual Studio process (by PID). Call vs.list_instances first to see options.")]
+    public async Task<VsStatus> VsSelect(
+        [Description("Process id of the VS instance to target.")] int processId,
+        CancellationToken ct = default)
+    {
+        await _connection.ConnectToAsync(processId, ct).ConfigureAwait(false);
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.GetStatusAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/src/VSMCP.Shared/Dtos.cs
+++ b/src/VSMCP.Shared/Dtos.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public sealed class HandshakeResult
+{
+    public int ProtocolMajor { get; set; }
+    public int ProtocolMinor { get; set; }
+    public string? ExtensionVersion { get; set; }
+    public int VsProcessId { get; set; }
+    public string? VsEdition { get; set; }
+    public string? VsVersion { get; set; }
+}
+
+public sealed class PingResult
+{
+    public string Message { get; set; } = "pong";
+    public long ServerTimestampMs { get; set; }
+}
+
+public sealed class VsStatus
+{
+    public bool SolutionOpen { get; set; }
+    public string? SolutionPath { get; set; }
+    public string? SolutionName { get; set; }
+    public string? ActiveConfiguration { get; set; }
+    public string? ActivePlatform { get; set; }
+    public string? StartupProject { get; set; }
+    public bool Debugging { get; set; }
+    public string? DebugMode { get; set; }
+    public List<string> LoadedProjects { get; set; } = new();
+}
+
+public sealed class VsInstance
+{
+    public int ProcessId { get; set; }
+    public string PipeName { get; set; } = "";
+    public string? MainWindowTitle { get; set; }
+    public string? SolutionPath { get; set; }
+}

--- a/src/VSMCP.Shared/ErrorCodes.cs
+++ b/src/VSMCP.Shared/ErrorCodes.cs
@@ -1,0 +1,14 @@
+namespace VSMCP.Shared;
+
+public static class ErrorCodes
+{
+    public const string NotConnected = "VSMCP-not-connected";
+    public const string NotDebugging = "VSMCP-not-debugging";
+    public const string WrongState = "VSMCP-wrong-state";
+    public const string TargetBusy = "VSMCP-target-busy";
+    public const string NotFound = "VSMCP-not-found";
+    public const string Timeout = "VSMCP-timeout";
+    public const string InteropFault = "VSMCP-interop-fault";
+    public const string Unsupported = "VSMCP-unsupported";
+    public const string UpgradeRequired = "VSMCP-upgrade-required";
+}

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VSMCP.Shared;
+
+/// <summary>
+/// JSON-RPC contract implemented by the VSIX and called by VSMCP.Server.
+/// Method names are stable — any breaking change bumps <see cref="ProtocolVersion"/>.
+/// </summary>
+public interface IVsmcpRpc
+{
+    Task<HandshakeResult> HandshakeAsync(int clientMajor, int clientMinor, CancellationToken cancellationToken = default);
+
+    Task<PingResult> PingAsync(CancellationToken cancellationToken = default);
+
+    Task<VsStatus> GetStatusAsync(CancellationToken cancellationToken = default);
+}

--- a/src/VSMCP.Shared/PipeNaming.cs
+++ b/src/VSMCP.Shared/PipeNaming.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics;
+
+namespace VSMCP.Shared;
+
+public static class PipeNaming
+{
+    public const string Prefix = "VSMCP.";
+
+    public static string ForProcess(int pid) => $"{Prefix}{pid}";
+
+    public static string ForCurrentProcess() => ForProcess(Process.GetCurrentProcess().Id);
+
+    public static bool IsVsmcpPipe(string name) => name.StartsWith(Prefix, System.StringComparison.Ordinal);
+}

--- a/src/VSMCP.Shared/ProtocolVersion.cs
+++ b/src/VSMCP.Shared/ProtocolVersion.cs
@@ -1,0 +1,9 @@
+namespace VSMCP.Shared;
+
+/// <summary>RPC protocol version — bumped on breaking contract changes.</summary>
+public static class ProtocolVersion
+{
+    public const int Major = 0;
+    public const int Minor = 1;
+    public static string DisplayString => $"{Major}.{Minor}";
+}

--- a/src/VSMCP.Shared/VSMCP.Shared.csproj
+++ b/src/VSMCP.Shared/VSMCP.Shared.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net472;net9.0</TargetFrameworks>
+    <RootNamespace>VSMCP.Shared</RootNamespace>
+    <AssemblyName>VSMCP.Shared</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="StreamJsonRpc" Version="2.19.27" />
+  </ItemGroup>
+</Project>

--- a/src/VSMCP.Vsix/PipeHost.cs
+++ b/src/VSMCP.Vsix/PipeHost.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Threading;
+using StreamJsonRpc;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// Accepts named-pipe connections from VSMCP.Server and dispatches RPC calls to <see cref="RpcTarget"/>.
+/// One pipe per VS instance: name = "VSMCP.&lt;pid&gt;". ACL = current user only.
+/// </summary>
+internal sealed class PipeHost : IDisposable
+{
+    private readonly VSMCPPackage _package;
+    private readonly JoinableTaskFactory _jtf;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly string _pipeName;
+
+    public PipeHost(VSMCPPackage package, JoinableTaskFactory jtf)
+    {
+        _package = package;
+        _jtf = jtf;
+        _pipeName = PipeNaming.ForCurrentProcess();
+    }
+
+    public void Start()
+    {
+        _ = Task.Run(() => AcceptLoopAsync(_cts.Token));
+    }
+
+    private async Task AcceptLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            NamedPipeServerStream? server = null;
+            try
+            {
+                server = CreateServerStream(_pipeName);
+                await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
+
+                var target = new RpcTarget(_package, _jtf);
+                var rpc = JsonRpc.Attach(server, target);
+                // Each connection owns its own stream; don't await Completion here — we want to
+                // accept the next connection immediately. The rpc/stream dispose together.
+                _ = rpc.Completion.ContinueWith(_ => server.Dispose(), TaskScheduler.Default);
+                server = null; // ownership transferred
+            }
+            catch (OperationCanceledException) { return; }
+            catch (Exception)
+            {
+                // Swallow and keep listening — a bad client shouldn't take down the host.
+                server?.Dispose();
+                try { await Task.Delay(100, ct).ConfigureAwait(false); } catch { return; }
+            }
+        }
+    }
+
+    private static NamedPipeServerStream CreateServerStream(string name)
+    {
+        var security = new PipeSecurity();
+        var sid = WindowsIdentity.GetCurrent().User
+                  ?? throw new InvalidOperationException("Cannot determine current user SID.");
+        security.AddAccessRule(new PipeAccessRule(sid, PipeAccessRights.ReadWrite | PipeAccessRights.CreateNewInstance, AccessControlType.Allow));
+
+        return new NamedPipeServerStream(
+            pipeName: name,
+            direction: PipeDirection.InOut,
+            maxNumberOfServerInstances: NamedPipeServerStream.MaxAllowedServerInstances,
+            transmissionMode: PipeTransmissionMode.Byte,
+            options: PipeOptions.Asynchronous,
+            inBufferSize: 64 * 1024,
+            outBufferSize: 64 * 1024,
+            pipeSecurity: security);
+    }
+
+    public void Dispose()
+    {
+        try { _cts.Cancel(); } catch { }
+        _cts.Dispose();
+    }
+}

--- a/src/VSMCP.Vsix/RpcTarget.cs
+++ b/src/VSMCP.Vsix/RpcTarget.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// JSON-RPC method surface. VS APIs touched here must run on the UI thread;
+/// we switch at the top of each method so callers can stay free-threaded.
+/// </summary>
+internal sealed class RpcTarget : IVsmcpRpc
+{
+    private readonly VSMCPPackage _package;
+    private readonly JoinableTaskFactory _jtf;
+
+    public RpcTarget(VSMCPPackage package, JoinableTaskFactory jtf)
+    {
+        _package = package;
+        _jtf = jtf;
+    }
+
+    public async Task<HandshakeResult> HandshakeAsync(int clientMajor, int clientMinor, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        string? edition = null;
+        string? version = null;
+        if (await _package.GetServiceAsync(typeof(SVsShell)) is IVsShell shell)
+        {
+            shell.GetProperty((int)__VSSPROPID5.VSSPROPID_ReleaseVersion, out var verObj);
+            version = verObj as string;
+            shell.GetProperty((int)__VSSPROPID5.VSSPROPID_AppBrandName, out var editionObj);
+            edition = editionObj as string;
+        }
+
+        return new HandshakeResult
+        {
+            ProtocolMajor = ProtocolVersion.Major,
+            ProtocolMinor = ProtocolVersion.Minor,
+            ExtensionVersion = typeof(RpcTarget).Assembly.GetName().Version?.ToString(),
+            VsProcessId = Process.GetCurrentProcess().Id,
+            VsEdition = edition,
+            VsVersion = version,
+        };
+    }
+
+    public async Task<PingResult> PingAsync(CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        return new PingResult
+        {
+            Message = "pong",
+            ServerTimestampMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        };
+    }
+
+    public async Task<VsStatus> GetStatusAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        var status = new VsStatus();
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            return status;
+
+        var solution = dte.Solution;
+        if (solution?.IsOpen == true && !string.IsNullOrEmpty(solution.FullName))
+        {
+            status.SolutionOpen = true;
+            status.SolutionPath = solution.FullName;
+            status.SolutionName = Path.GetFileNameWithoutExtension(solution.FullName);
+
+            try
+            {
+                var active = solution.SolutionBuild?.ActiveConfiguration as EnvDTE80.SolutionConfiguration2;
+                status.ActiveConfiguration = active?.Name;
+                status.ActivePlatform = active?.PlatformName;
+            }
+            catch { }
+
+            try
+            {
+                if (solution.SolutionBuild?.StartupProjects is Array startup && startup.Length > 0
+                    && startup.GetValue(0) is string sp)
+                {
+                    status.StartupProject = sp;
+                }
+            }
+            catch { }
+
+            foreach (EnvDTE.Project p in solution.Projects)
+            {
+                if (p is null) continue;
+                try { status.LoadedProjects.Add(p.UniqueName ?? p.Name); } catch { }
+            }
+        }
+
+        var debugger = dte.Debugger;
+        if (debugger is not null)
+        {
+            status.Debugging = debugger.CurrentMode != EnvDTE.dbgDebugMode.dbgDesignMode;
+            status.DebugMode = debugger.CurrentMode.ToString();
+        }
+
+        return status;
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="17.0">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">17.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
+    <VsTargetFrameworkVersion>v4.7.2</VsTargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{A3333333-3333-3333-3333-333333333333}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>VSMCP.Vsix</RootNamespace>
+    <AssemblyName>VSMCP.Vsix</AssemblyName>
+    <FileAlignment>512</FileAlignment>
+    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
+    <UseCodebase>true</UseCodebase>
+    <CreateVsixContainer>true</CreateVsixContainer>
+    <DeployExtension>false</DeployExtension>
+    <StartAction>Program</StartAction>
+    <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+    <LangVersion>latest</LangVersion>
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="VSMCPPackage.cs" />
+    <Compile Include="PipeHost.cs" />
+    <Compile Include="RpcTarget.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="source.extension.vsixmanifest">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.9.37000" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.9.3365" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" PrivateAssets="all" />
+    <PackageReference Include="StreamJsonRpc" Version="2.19.27" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VSMCP.Shared\VSMCP.Shared.csproj">
+      <Project>{A1111111-1111-1111-1111-111111111111}</Project>
+      <Name>VSMCP.Shared</Name>
+      <Private>false</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/VSMCP.Vsix/VSMCPPackage.cs
+++ b/src/VSMCP.Vsix/VSMCPPackage.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Microsoft.VisualStudio.Shell;
+using Task = System.Threading.Tasks.Task;
+
+namespace VSMCP.Vsix;
+
+[PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
+[Guid(PackageGuidString)]
+[ProvideAutoLoad(Microsoft.VisualStudio.VSConstants.UICONTEXT.NoSolution_string, PackageAutoLoadFlags.BackgroundLoad)]
+[ProvideAutoLoad(Microsoft.VisualStudio.VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
+public sealed class VSMCPPackage : AsyncPackage
+{
+    public const string PackageGuidString = "7e0b4e3e-0000-0000-0000-000000000001";
+
+    private PipeHost? _pipeHost;
+
+    protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        _pipeHost = new PipeHost(this, JoinableTaskFactory);
+        _pipeHost.Start();
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _pipeHost?.Dispose();
+            _pipeHost = null;
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/src/VSMCP.Vsix/source.extension.vsixmanifest
+++ b/src/VSMCP.Vsix/source.extension.vsixmanifest
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="VSMCP.pauliver.7e0b4e3e-0000-0000-0000-000000000001" Version="0.1.0" Language="en-US" Publisher="pauliver" />
+    <DisplayName>VSMCP</DisplayName>
+    <Description xml:space="preserve">Model Context Protocol server for Visual Studio 2022. Lets AI assistants (Claude and friends) drive the VS debugger, profiler, and crash-dump analyzer.</Description>
+    <MoreInfo>https://github.com/pauliver/VSMCP</MoreInfo>
+    <GettingStartedGuide>https://github.com/pauliver/VSMCP#quick-start</GettingStartedGuide>
+    <Tags>mcp, claude, ai, debugger, profiler, dump</Tags>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.9,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.9,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+    <InstallationTarget Id="Microsoft.VisualStudio.Enterprise" Version="[17.9,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.7.2,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.9,18.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+  </Assets>
+</PackageManifest>

--- a/src/VSMCP.sln
+++ b/src/VSMCP.sln
@@ -1,0 +1,33 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VSMCP.Shared", "VSMCP.Shared\VSMCP.Shared.csproj", "{A1111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VSMCP.Server", "VSMCP.Server\VSMCP.Server.csproj", "{A2222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VSMCP.Vsix", "VSMCP.Vsix\VSMCP.Vsix.csproj", "{A3333333-3333-3333-3333-333333333333}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A2222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A2222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Implements #1 (M1 Foundations).

## What's in the box
- `src/VSMCP.sln` with three projects and cross-TFM \`VSMCP.Shared\`.
- **VSMCP.Vsix** (net472 / VSSDK): \`AsyncPackage\` auto-loads on VS start, hosts a user-ACL'd \`NamedPipeServerStream\` at \`\\.\pipe\VSMCP.<pid>\`, dispatches via \`StreamJsonRpc\`. Every VS API call marshals onto the UI thread with \`JoinableTaskFactory\`.
- **VSMCP.Server** (net9.0): MCP stdio server using \`ModelContextProtocol\` 1.2. Tools: \`ping\`, \`vs.status\`, \`vs.list_instances\`, \`vs.select\`.
- Handshake with protocol version check → \`VSMCP-upgrade-required\` on mismatch.
- GitHub Actions \`build.yml\` on \`windows-latest\`, uploads VSIX + server artifacts.
- MIT \`LICENSE\`, \`Directory.Build.props\`, \`global.json\`.

## Build
\`\`\`
msbuild src/VSMCP.sln -t:Restore,Build -p:Configuration=Debug
\`\`\`
Produces \`src/VSMCP.Vsix/bin/Debug/VSMCP.Vsix.vsix\`.

## What's **not** in this PR (follow-ups)
- Smoke test against a real VS instance (needs the VSIX installed into the experimental hive). Will be a separate validation step.
- Menu command \`Tools → VSMCP → Enable\` — deferred to M10 (needs a \`.vsct\`).
- Integration tests in the experimental hive — deferred to its own task.
- MSB3277 warnings on VSIX build are cosmetic (VS's normal assembly unification).

## Draft
Marking draft until someone can install the VSIX into a VS experimental hive and confirm \`ping\` round-trips from Claude Code.