### PR TITLE
M2: Solution, Project, and File/editor tool surface

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
@@ -48,5 +49,190 @@ public sealed class VsmcpTools
         await _connection.ConnectToAsync(processId, ct).ConfigureAwait(false);
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.GetStatusAsync(ct).ConfigureAwait(false);
+    }
+
+    // -------- Solution --------
+
+    [McpServerTool(Name = "solution.info")]
+    [Description("Return details about the currently open solution: path, active configuration/platform, startup project, and loaded projects.")]
+    public async Task<SolutionInfo> SolutionInfo(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.SolutionInfoAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "solution.open")]
+    [Description("Open a .sln file in the connected Visual Studio. Closes any currently open solution first.")]
+    public async Task<SolutionInfo> SolutionOpen(
+        [Description("Absolute path to the .sln file.")] string path,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.SolutionOpenAsync(path, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "solution.close")]
+    [Description("Close the currently open solution.")]
+    public async Task SolutionClose(
+        [Description("Prompt to save modified documents before closing.")] bool saveFirst = true,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        await proxy.SolutionCloseAsync(saveFirst, ct).ConfigureAwait(false);
+    }
+
+    // -------- Project --------
+
+    [McpServerTool(Name = "project.list")]
+    [Description("Enumerate every concrete (non-folder) project in the current solution.")]
+    public async Task<IReadOnlyList<ProjectInfo>> ProjectList(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ProjectListAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "project.add")]
+    [Description("Add an existing project file to the current solution, or instantiate a project template.")]
+    public async Task<ProjectInfo> ProjectAdd(
+        [Description("Path to an existing .csproj/.vbproj/.fsproj/.vcxproj, or to a project template (.vstemplate).")] string templateOrProjectPath,
+        [Description("Destination directory when adding from a template. Ignored when adding an existing project.")] string destinationPath = "",
+        [Description("Name for the new project when adding from a template. Defaults to the destination folder name.")] string? projectName = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ProjectAddAsync(templateOrProjectPath, destinationPath, projectName, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "project.remove")]
+    [Description("Remove a project from the solution (does not delete files from disk).")]
+    public async Task ProjectRemove(
+        [Description("Project id (UniqueName), name, or full path.")] string projectId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        await proxy.ProjectRemoveAsync(projectId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "project.properties.get")]
+    [Description("Read project properties. Pass an empty list to fetch all readable properties.")]
+    public async Task<IReadOnlyList<PropertyValue>> ProjectPropertiesGet(
+        [Description("Project id (UniqueName), name, or full path.")] string projectId,
+        [Description("Property names to read; omit or pass an empty array for all.")] IReadOnlyList<string>? keys = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ProjectPropertiesGetAsync(projectId, keys, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "project.properties.set")]
+    [Description("Set one or more project properties. Values must be the string form expected by MSBuild.")]
+    public async Task ProjectPropertiesSet(
+        [Description("Project id (UniqueName), name, or full path.")] string projectId,
+        [Description("Map of property name to new value. A null value clears the property.")] IReadOnlyDictionary<string, string?> values,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        await proxy.ProjectPropertiesSetAsync(projectId, values, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "project.file.add")]
+    [Description("Add a file to a project. When linkOnly is true the file is referenced in-place; otherwise it is copied under the project folder.")]
+    public async Task<ProjectItemRef> ProjectFileAdd(
+        [Description("Project id (UniqueName), name, or full path.")] string projectId,
+        [Description("Absolute or project-relative file path to add.")] string path,
+        [Description("Add as a link rather than copying into the project folder.")] bool linkOnly = false,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ProjectFileAddAsync(projectId, path, linkOnly, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "project.file.remove")]
+    [Description("Remove a file from a project. Optionally delete the file from disk.")]
+    public async Task ProjectFileRemove(
+        [Description("Project id (UniqueName), name, or full path.")] string projectId,
+        [Description("Absolute or project-relative file path to remove.")] string path,
+        [Description("Also delete the file from disk. Default: false.")] bool deleteFromDisk = false,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        await proxy.ProjectFileRemoveAsync(projectId, path, deleteFromDisk, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "project.folder.create")]
+    [Description("Create a (possibly nested) folder inside a project. Intermediate folders are created as needed.")]
+    public async Task<ProjectItemRef> ProjectFolderCreate(
+        [Description("Project id (UniqueName), name, or full path.")] string projectId,
+        [Description("Relative folder path, using '/' or '\\' as separator.")] string path,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ProjectFolderCreateAsync(projectId, path, ct).ConfigureAwait(false);
+    }
+
+    // -------- File / editor --------
+
+    [McpServerTool(Name = "file.read")]
+    [Description("Read a file's contents. If the file is open in the editor, returns the live (possibly unsaved) buffer contents.")]
+    public async Task<FileReadResult> FileRead(
+        [Description("Absolute file path.")] string path,
+        [Description("Optional 1-based inclusive range. Omit to read the whole file.")] FileRange? range = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.FileReadAsync(path, range, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "file.write")]
+    [Description("Overwrite a file. If the file is open in the editor, the write goes through the text buffer so VS undo/redo still works.")]
+    public async Task<FileWriteResult> FileWrite(
+        [Description("Absolute file path.")] string path,
+        [Description("New file contents.")] string content,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.FileWriteAsync(path, content, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "file.replace_range")]
+    [Description("Replace a 1-based inclusive range in a file with new text. Goes through the text buffer when the file is open.")]
+    public async Task<FileWriteResult> FileReplaceRange(
+        [Description("Absolute file path.")] string path,
+        [Description("1-based inclusive range to replace.")] FileRange range,
+        [Description("Replacement text. Empty string deletes the range.")] string text,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.FileReplaceRangeAsync(path, range, text, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "editor.open")]
+    [Description("Open a file in the Visual Studio editor and optionally move the caret to a 1-based (line, column).")]
+    public async Task EditorOpen(
+        [Description("Absolute file path.")] string path,
+        [Description("1-based line number to move the caret to.")] int? line = null,
+        [Description("1-based column number to move the caret to.")] int? column = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        await proxy.EditorOpenAsync(path, line, column, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "editor.save")]
+    [Description("Save a single open document by its file path.")]
+    public async Task EditorSave(
+        [Description("Absolute file path of the document to save.")] string path,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        await proxy.EditorSaveAsync(path, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "editor.save_all")]
+    [Description("Save every open, dirty document in the connected Visual Studio.")]
+    public async Task EditorSaveAll(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        await proxy.EditorSaveAllAsync(ct).ConfigureAwait(false);
     }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,9 +10,32 @@ namespace VSMCP.Shared;
 /// </summary>
 public interface IVsmcpRpc
 {
+    // -------- Meta --------
     Task<HandshakeResult> HandshakeAsync(int clientMajor, int clientMinor, CancellationToken cancellationToken = default);
-
     Task<PingResult> PingAsync(CancellationToken cancellationToken = default);
-
     Task<VsStatus> GetStatusAsync(CancellationToken cancellationToken = default);
+
+    // -------- Solution --------
+    Task<SolutionInfo> SolutionInfoAsync(CancellationToken cancellationToken = default);
+    Task<SolutionInfo> SolutionOpenAsync(string path, CancellationToken cancellationToken = default);
+    Task SolutionCloseAsync(bool saveFirst, CancellationToken cancellationToken = default);
+
+    // -------- Project --------
+    Task<IReadOnlyList<ProjectInfo>> ProjectListAsync(CancellationToken cancellationToken = default);
+    Task<ProjectInfo> ProjectAddAsync(string templatePathOrExistingFile, string destinationPath, string? projectName, CancellationToken cancellationToken = default);
+    Task ProjectRemoveAsync(string projectId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<PropertyValue>> ProjectPropertiesGetAsync(string projectId, IReadOnlyList<string>? keys, CancellationToken cancellationToken = default);
+    Task ProjectPropertiesSetAsync(string projectId, IReadOnlyDictionary<string, string?> values, CancellationToken cancellationToken = default);
+    Task<ProjectItemRef> ProjectFileAddAsync(string projectId, string path, bool linkOnly, CancellationToken cancellationToken = default);
+    Task ProjectFileRemoveAsync(string projectId, string path, bool deleteFromDisk, CancellationToken cancellationToken = default);
+    Task<ProjectItemRef> ProjectFolderCreateAsync(string projectId, string path, CancellationToken cancellationToken = default);
+
+    // -------- File / editor --------
+    Task<FileReadResult> FileReadAsync(string path, FileRange? range, CancellationToken cancellationToken = default);
+    Task<FileWriteResult> FileWriteAsync(string path, string content, CancellationToken cancellationToken = default);
+    Task<FileWriteResult> FileReplaceRangeAsync(string path, FileRange range, string text, CancellationToken cancellationToken = default);
+
+    Task EditorOpenAsync(string path, int? line, int? column, CancellationToken cancellationToken = default);
+    Task EditorSaveAsync(string path, CancellationToken cancellationToken = default);
+    Task EditorSaveAllAsync(CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M2Dtos.cs
+++ b/src/VSMCP.Shared/M2Dtos.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public sealed class SolutionInfo
+{
+    public bool IsOpen { get; set; }
+    public string? Path { get; set; }
+    public string? Name { get; set; }
+    public string? ActiveConfiguration { get; set; }
+    public string? ActivePlatform { get; set; }
+    public string? StartupProject { get; set; }
+    public List<ProjectInfo> Projects { get; set; } = new();
+}
+
+public sealed class ProjectInfo
+{
+    /// <summary>Stable identifier for the project within the solution (DTE UniqueName).</summary>
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string? Kind { get; set; }
+    public string? FullPath { get; set; }
+    public string? OutputType { get; set; }
+    public string? TargetFramework { get; set; }
+}
+
+/// <summary>
+/// 1-based inclusive range for text edits. endLine == startLine &amp;&amp; endColumn == startColumn
+/// is an empty insertion point.
+/// </summary>
+public sealed class FileRange
+{
+    public int StartLine { get; set; } = 1;
+    public int StartColumn { get; set; } = 1;
+    public int EndLine { get; set; } = 1;
+    public int EndColumn { get; set; } = 1;
+}
+
+public sealed class FileReadResult
+{
+    public string Path { get; set; } = "";
+    public string Content { get; set; } = "";
+    public bool OpenInEditor { get; set; }
+    public bool HasUnsavedChanges { get; set; }
+}
+
+public sealed class FileWriteResult
+{
+    public string Path { get; set; } = "";
+    public int BytesWritten { get; set; }
+    public bool WentThroughEditor { get; set; }
+}
+
+public enum ProjectItemKind
+{
+    Unknown = 0,
+    File = 1,
+    Folder = 2,
+    Project = 3,
+}
+
+public sealed class ProjectItemRef
+{
+    public string ProjectId { get; set; } = "";
+    public string RelativePath { get; set; } = "";
+    public string? FullPath { get; set; }
+    public ProjectItemKind Kind { get; set; }
+}
+
+public sealed class PropertyValue
+{
+    public string Name { get; set; } = "";
+    public string? Value { get; set; }
+    public bool Readable { get; set; }
+    public bool Writable { get; set; }
+}

--- a/src/VSMCP.Vsix/RpcTarget.Files.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Files.cs
@@ -1,0 +1,201 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Text;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public async Task<FileReadResult> FileReadAsync(string path, FileRange? range, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Path is required.");
+
+        var buffer = VsHelpers.TryGetOpenTextBuffer(_package, path);
+        string content;
+        bool openInEditor = buffer is not null;
+        bool hasUnsavedChanges = false;
+
+        if (buffer is not null)
+        {
+            var snapshot = buffer.CurrentSnapshot;
+            if (range is not null)
+            {
+                var span = VsHelpers.ToSpan(snapshot, range);
+                content = snapshot.GetText(span);
+            }
+            else
+            {
+                content = snapshot.GetText();
+            }
+
+            try
+            {
+                if (buffer.Properties.TryGetProperty<ITextDocument>(typeof(ITextDocument), out var doc))
+                    hasUnsavedChanges = doc.IsDirty;
+            }
+            catch { }
+        }
+        else
+        {
+            if (!File.Exists(path))
+                throw new VsmcpException(ErrorCodes.NotFound, $"File not found: {path}");
+
+            var full = File.ReadAllText(path);
+            if (range is not null)
+            {
+                var (start, length) = VsHelpers.ToOffsets(full, range);
+                content = full.Substring(start, length);
+            }
+            else
+            {
+                content = full;
+            }
+        }
+
+        return new FileReadResult
+        {
+            Path = path,
+            Content = content,
+            OpenInEditor = openInEditor,
+            HasUnsavedChanges = hasUnsavedChanges,
+        };
+    }
+
+    public async Task<FileWriteResult> FileWriteAsync(string path, string content, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Path is required.");
+
+        content ??= string.Empty;
+        var buffer = VsHelpers.TryGetOpenTextBuffer(_package, path);
+        bool wentThroughEditor = false;
+
+        if (buffer is not null)
+        {
+            var snapshot = buffer.CurrentSnapshot;
+            using var edit = buffer.CreateEdit();
+            edit.Replace(new Span(0, snapshot.Length), content);
+            edit.Apply();
+            wentThroughEditor = true;
+        }
+        else
+        {
+            var dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+            File.WriteAllText(path, content);
+        }
+
+        return new FileWriteResult
+        {
+            Path = path,
+            BytesWritten = Encoding.UTF8.GetByteCount(content),
+            WentThroughEditor = wentThroughEditor,
+        };
+    }
+
+    public async Task<FileWriteResult> FileReplaceRangeAsync(string path, FileRange range, string text, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Path is required.");
+        if (range is null)
+            throw new VsmcpException(ErrorCodes.NotFound, "Range is required.");
+
+        text ??= string.Empty;
+        var buffer = VsHelpers.TryGetOpenTextBuffer(_package, path);
+        bool wentThroughEditor = false;
+
+        if (buffer is not null)
+        {
+            var snapshot = buffer.CurrentSnapshot;
+            var span = VsHelpers.ToSpan(snapshot, range);
+            using var edit = buffer.CreateEdit();
+            edit.Replace(span, text);
+            edit.Apply();
+            wentThroughEditor = true;
+        }
+        else
+        {
+            if (!File.Exists(path))
+                throw new VsmcpException(ErrorCodes.NotFound, $"File not found: {path}");
+
+            var full = File.ReadAllText(path);
+            var (start, length) = VsHelpers.ToOffsets(full, range);
+            var sb = new StringBuilder(full.Length + text.Length);
+            sb.Append(full, 0, start);
+            sb.Append(text);
+            sb.Append(full, start + length, full.Length - (start + length));
+            File.WriteAllText(path, sb.ToString());
+        }
+
+        return new FileWriteResult
+        {
+            Path = path,
+            BytesWritten = Encoding.UTF8.GetByteCount(text),
+            WentThroughEditor = wentThroughEditor,
+        };
+    }
+
+    public async Task EditorOpenAsync(string path, int? line, int? column, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Path is required.");
+        if (!File.Exists(path))
+            throw new VsmcpException(ErrorCodes.NotFound, $"File not found: {path}");
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var window = dte.ItemOperations.OpenFile(path, EnvDTE.Constants.vsViewKindPrimary);
+        if (line is not null && window?.Document?.Selection is EnvDTE.TextSelection sel)
+        {
+            sel.MoveToLineAndOffset(Math.Max(1, line.Value), Math.Max(1, column ?? 1));
+        }
+    }
+
+    public async Task EditorSaveAsync(string path, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Path is required.");
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        foreach (EnvDTE.Document doc in dte.Documents)
+        {
+            if (doc is null) continue;
+            if (string.Equals(doc.FullName, path, StringComparison.OrdinalIgnoreCase))
+            {
+                doc.Save();
+                return;
+            }
+        }
+        throw new VsmcpException(ErrorCodes.NotFound, $"No open document matching '{path}'.");
+    }
+
+    public async Task EditorSaveAllAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        dte.Documents.SaveAll();
+    }
+}

--- a/src/VSMCP.Vsix/RpcTarget.Project.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Project.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public async Task<IReadOnlyList<ProjectInfo>> ProjectListAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        var list = new List<ProjectInfo>();
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            return list;
+
+        foreach (var p in VsHelpers.EnumerateProjects(dte.Solution))
+            list.Add(VsHelpers.ToInfo(p));
+        return list;
+    }
+
+    public async Task<ProjectInfo> ProjectAddAsync(string templatePathOrExistingFile, string destinationPath, string? projectName, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(templatePathOrExistingFile))
+            throw new VsmcpException(ErrorCodes.NotFound, "Template or project path is required.");
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var solution = dte.Solution
+            ?? throw new VsmcpException(ErrorCodes.WrongState, "No solution is open.");
+
+        bool isExistingProject =
+            File.Exists(templatePathOrExistingFile) &&
+            (templatePathOrExistingFile.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase)
+             || templatePathOrExistingFile.EndsWith(".vbproj", StringComparison.OrdinalIgnoreCase)
+             || templatePathOrExistingFile.EndsWith(".fsproj", StringComparison.OrdinalIgnoreCase)
+             || templatePathOrExistingFile.EndsWith(".vcxproj", StringComparison.OrdinalIgnoreCase));
+
+        EnvDTE.Project? added = null;
+
+        if (isExistingProject)
+        {
+            added = solution.AddFromFile(templatePathOrExistingFile, Exclusive: false);
+        }
+        else
+        {
+            if (string.IsNullOrWhiteSpace(destinationPath))
+                throw new VsmcpException(ErrorCodes.NotFound, "Destination path is required when adding from a template.");
+
+            var name = string.IsNullOrWhiteSpace(projectName)
+                ? Path.GetFileName(destinationPath.TrimEnd('\\', '/'))
+                : projectName!;
+
+            Directory.CreateDirectory(destinationPath);
+            solution.AddFromTemplate(templatePathOrExistingFile, destinationPath, name, Exclusive: false);
+
+            foreach (var p in VsHelpers.EnumerateProjects(solution))
+            {
+                if (string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    added = p;
+                    break;
+                }
+            }
+        }
+
+        if (added is null)
+            throw new VsmcpException(ErrorCodes.InteropFault, "Project was added but could not be resolved.");
+
+        return VsHelpers.ToInfo(added);
+    }
+
+    public async Task ProjectRemoveAsync(string projectId, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var project = VsHelpers.RequireProject(dte.Solution, projectId);
+        dte.Solution.Remove(project);
+    }
+
+    public async Task<IReadOnlyList<PropertyValue>> ProjectPropertiesGetAsync(string projectId, IReadOnlyList<string>? keys, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var project = VsHelpers.RequireProject(dte.Solution, projectId);
+        var props = project.Properties;
+        var results = new List<PropertyValue>();
+        if (props is null) return results;
+
+        if (keys is { Count: > 0 })
+        {
+            foreach (var key in keys)
+            {
+                var pv = TryReadProperty(props, key);
+                if (pv is not null) results.Add(pv);
+            }
+        }
+        else
+        {
+            foreach (EnvDTE.Property prop in props)
+            {
+                if (prop is null) continue;
+                var pv = TryReadProperty(props, prop.Name);
+                if (pv is not null) results.Add(pv);
+            }
+        }
+
+        return results;
+    }
+
+    private static PropertyValue? TryReadProperty(EnvDTE.Properties props, string name)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            var p = props.Item(name);
+            if (p is null) return null;
+            string? value = null;
+            bool readable = true;
+            try { value = p.Value?.ToString(); } catch { readable = false; }
+            return new PropertyValue { Name = name, Value = value, Readable = readable, Writable = true };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public async Task ProjectPropertiesSetAsync(string projectId, IReadOnlyDictionary<string, string?> values, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (values is null || values.Count == 0) return;
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var project = VsHelpers.RequireProject(dte.Solution, projectId);
+        var props = project.Properties
+            ?? throw new VsmcpException(ErrorCodes.Unsupported, "Project does not expose properties.");
+
+        foreach (var kv in values)
+        {
+            try
+            {
+                var prop = props.Item(kv.Key);
+                if (prop is null) continue;
+                prop.Value = kv.Value;
+            }
+            catch (Exception ex)
+            {
+                throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to set property '{kv.Key}': {ex.Message}", ex);
+            }
+        }
+    }
+
+    public async Task<ProjectItemRef> ProjectFileAddAsync(string projectId, string path, bool linkOnly, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new VsmcpException(ErrorCodes.NotFound, "File path is required.");
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var project = VsHelpers.RequireProject(dte.Solution, projectId);
+        var items = project.ProjectItems
+            ?? throw new VsmcpException(ErrorCodes.Unsupported, "Project does not support items.");
+
+        EnvDTE.ProjectItem added;
+        if (linkOnly)
+        {
+            if (!File.Exists(path))
+                throw new VsmcpException(ErrorCodes.NotFound, $"File not found: {path}");
+            added = items.AddFromFile(path);
+        }
+        else
+        {
+            var projectDir = Path.GetDirectoryName(project.FullName) ?? "";
+            var target = Path.IsPathRooted(path) ? path : Path.Combine(projectDir, path);
+            if (!File.Exists(target))
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+                File.WriteAllText(target, string.Empty);
+            }
+            added = items.AddFromFileCopy(target);
+        }
+
+        string? full = null;
+        try { full = added.FileCount >= 1 ? added.FileNames[1] : null; } catch { }
+
+        var projDir = Path.GetDirectoryName(project.FullName) ?? "";
+        string rel = full is not null && full.StartsWith(projDir, StringComparison.OrdinalIgnoreCase)
+            ? full.Substring(projDir.Length).TrimStart('\\', '/')
+            : path;
+
+        return new ProjectItemRef
+        {
+            ProjectId = project.UniqueName ?? project.Name,
+            RelativePath = rel,
+            FullPath = full,
+            Kind = ProjectItemKind.File,
+        };
+    }
+
+    public async Task ProjectFileRemoveAsync(string projectId, string path, bool deleteFromDisk, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var project = VsHelpers.RequireProject(dte.Solution, projectId);
+        var item = VsHelpers.FindItem(project, path)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"File '{path}' not found in project '{projectId}'.");
+
+        string? fullPath = null;
+        try { fullPath = item.FileCount >= 1 ? item.FileNames[1] : null; } catch { }
+
+        if (deleteFromDisk)
+            item.Delete();
+        else
+            item.Remove();
+
+        if (deleteFromDisk && fullPath is not null && File.Exists(fullPath))
+        {
+            try { File.Delete(fullPath); } catch { }
+        }
+    }
+
+    public async Task<ProjectItemRef> ProjectFolderCreateAsync(string projectId, string path, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Folder path is required.");
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var project = VsHelpers.RequireProject(dte.Solution, projectId);
+        var segments = path.Replace('\\', '/').Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+        EnvDTE.ProjectItems? items = project.ProjectItems
+            ?? throw new VsmcpException(ErrorCodes.Unsupported, "Project does not support folders.");
+
+        EnvDTE.ProjectItem? current = null;
+        foreach (var seg in segments)
+        {
+            EnvDTE.ProjectItem? match = null;
+            foreach (EnvDTE.ProjectItem existing in items)
+            {
+                if (existing is null) continue;
+                if (string.Equals(existing.Name, seg, StringComparison.OrdinalIgnoreCase))
+                {
+                    match = existing;
+                    break;
+                }
+            }
+            current = match ?? items.AddFolder(seg);
+            items = current.ProjectItems;
+            if (items is null) break;
+        }
+
+        if (current is null)
+            throw new VsmcpException(ErrorCodes.InteropFault, "Failed to create folder.");
+
+        string? full = null;
+        try { full = current.FileCount >= 1 ? current.FileNames[1] : null; } catch { }
+
+        return new ProjectItemRef
+        {
+            ProjectId = project.UniqueName ?? project.Name,
+            RelativePath = string.Join("/", segments),
+            FullPath = full,
+            Kind = ProjectItemKind.Folder,
+        };
+    }
+}

--- a/src/VSMCP.Vsix/RpcTarget.Solution.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Solution.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public async Task<SolutionInfo> SolutionInfoAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        var info = new SolutionInfo();
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            return info;
+
+        var solution = dte.Solution;
+        if (solution?.IsOpen != true || string.IsNullOrEmpty(solution.FullName))
+            return info;
+
+        info.IsOpen = true;
+        info.Path = solution.FullName;
+        info.Name = Path.GetFileNameWithoutExtension(solution.FullName);
+
+        try
+        {
+            var active = solution.SolutionBuild?.ActiveConfiguration as EnvDTE80.SolutionConfiguration2;
+            info.ActiveConfiguration = active?.Name;
+            info.ActivePlatform = active?.PlatformName;
+        }
+        catch { }
+
+        try
+        {
+            if (solution.SolutionBuild?.StartupProjects is Array startup && startup.Length > 0
+                && startup.GetValue(0) is string sp)
+            {
+                info.StartupProject = sp;
+            }
+        }
+        catch { }
+
+        foreach (var p in VsHelpers.EnumerateProjects(solution))
+            info.Projects.Add(VsHelpers.ToInfo(p));
+
+        return info;
+    }
+
+    public async Task<SolutionInfo> SolutionOpenAsync(string path, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Solution path is required.");
+        if (!File.Exists(path))
+            throw new VsmcpException(ErrorCodes.NotFound, $"Solution file not found: {path}");
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        dte.Solution.Open(path);
+        return await SolutionInfoAsync(cancellationToken);
+    }
+
+    public async Task SolutionCloseAsync(bool saveFirst, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            return;
+
+        var solution = dte.Solution;
+        if (solution?.IsOpen != true) return;
+
+        solution.Close(saveFirst);
+    }
+}

--- a/src/VSMCP.Vsix/RpcTarget.cs
+++ b/src/VSMCP.Vsix/RpcTarget.cs
@@ -14,7 +14,7 @@ namespace VSMCP.Vsix;
 /// JSON-RPC method surface. VS APIs touched here must run on the UI thread;
 /// we switch at the top of each method so callers can stay free-threaded.
 /// </summary>
-internal sealed class RpcTarget : IVsmcpRpc
+internal sealed partial class RpcTarget : IVsmcpRpc
 {
     private readonly VSMCPPackage _package;
     private readonly JoinableTaskFactory _jtf;

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -62,6 +62,10 @@
     <Compile Include="VSMCPPackage.cs" />
     <Compile Include="PipeHost.cs" />
     <Compile Include="RpcTarget.cs" />
+    <Compile Include="RpcTarget.Solution.cs" />
+    <Compile Include="RpcTarget.Project.cs" />
+    <Compile Include="RpcTarget.Files.cs" />
+    <Compile Include="VsHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VSMCP.Vsix/VsHelpers.cs
+++ b/src/VSMCP.Vsix/VsHelpers.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// Free-floating helpers that must run on the UI thread. Callers are responsible for the switch.
+/// Throws <see cref="VsmcpException"/> with protocol-level error codes for non-fatal misuse.
+/// </summary>
+internal static class VsHelpers
+{
+    /// <summary>Recursively walk the solution and return every concrete (non-folder) project.</summary>
+    public static IEnumerable<EnvDTE.Project> EnumerateProjects(EnvDTE.Solution? solution)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (solution is null) yield break;
+
+        foreach (EnvDTE.Project p in solution.Projects)
+        {
+            if (p is null) continue;
+            foreach (var inner in Flatten(p))
+                yield return inner;
+        }
+    }
+
+    private static IEnumerable<EnvDTE.Project> Flatten(EnvDTE.Project p)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        if (string.Equals(p.Kind, EnvDTE.Constants.vsProjectKindSolutionItems, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(p.Kind, "{66A26720-8FB5-11D2-AA7E-00C04F688DDE}", StringComparison.OrdinalIgnoreCase)) // solution folder
+        {
+            if (p.ProjectItems is null) yield break;
+            foreach (EnvDTE.ProjectItem item in p.ProjectItems)
+            {
+                var sub = item?.SubProject;
+                if (sub is null) continue;
+                foreach (var inner in Flatten(sub))
+                    yield return inner;
+            }
+            yield break;
+        }
+
+        yield return p;
+    }
+
+    public static EnvDTE.Project RequireProject(EnvDTE.Solution? solution, string projectId)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        foreach (var p in EnumerateProjects(solution))
+        {
+            if (string.Equals(p.UniqueName, projectId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(p.Name, projectId, StringComparison.OrdinalIgnoreCase))
+                return p;
+
+            string? full = null;
+            try { full = p.FullName; } catch { }
+            if (!string.IsNullOrEmpty(full) && string.Equals(full, projectId, StringComparison.OrdinalIgnoreCase))
+                return p;
+        }
+
+        throw new VsmcpException(ErrorCodes.NotFound, $"No project matching id '{projectId}' in the current solution.");
+    }
+
+    public static ProjectInfo ToInfo(EnvDTE.Project project)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        string? fullPath = null;
+        try { fullPath = project.FullName; } catch { }
+
+        string? outputType = null;
+        string? tfm = null;
+        try { outputType = project.Properties?.Item("OutputType")?.Value?.ToString(); } catch { }
+        try { tfm = project.Properties?.Item("TargetFramework")?.Value?.ToString(); } catch { }
+
+        return new ProjectInfo
+        {
+            Id = project.UniqueName ?? project.Name ?? "",
+            Name = project.Name ?? "",
+            Kind = project.Kind,
+            FullPath = fullPath,
+            OutputType = outputType,
+            TargetFramework = tfm,
+        };
+    }
+
+    public static EnvDTE.ProjectItem? FindItem(EnvDTE.Project project, string relativeOrFullPath)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        string target = Path.IsPathRooted(relativeOrFullPath)
+            ? relativeOrFullPath
+            : Path.GetFullPath(Path.Combine(Path.GetDirectoryName(project.FullName) ?? "", relativeOrFullPath));
+
+        return FindItemRecursive(project.ProjectItems, target);
+    }
+
+    private static EnvDTE.ProjectItem? FindItemRecursive(EnvDTE.ProjectItems? items, string fullPath)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (items is null) return null;
+
+        foreach (EnvDTE.ProjectItem item in items)
+        {
+            if (item is null) continue;
+            for (short i = 1; i <= item.FileCount; i++)
+            {
+                string? file = null;
+                try { file = item.FileNames[i]; } catch { }
+                if (!string.IsNullOrEmpty(file) && string.Equals(file, fullPath, StringComparison.OrdinalIgnoreCase))
+                    return item;
+            }
+
+            var nested = FindItemRecursive(item.ProjectItems, fullPath);
+            if (nested is not null) return nested;
+        }
+        return null;
+    }
+
+    /// <summary>Get the open text buffer for a file, or null if the file isn't open.</summary>
+    public static Microsoft.VisualStudio.Text.ITextBuffer? TryGetOpenTextBuffer(IServiceProvider sp, string filePath)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (string.IsNullOrEmpty(filePath)) return null;
+
+        var rdt = sp.GetService(typeof(SVsRunningDocumentTable)) as IVsRunningDocumentTable;
+        if (rdt is null) return null;
+
+        var hr = rdt.FindAndLockDocument(
+            (uint)_VSRDTFLAGS.RDT_NoLock,
+            filePath,
+            out _, out _, out _,
+            out var docCookie);
+        if (hr != VSConstants.S_OK || docCookie == 0) return null;
+
+        rdt.GetDocumentInfo(docCookie, out _, out _, out _, out _, out _, out _, out var docData);
+        if (docData == IntPtr.Zero) return null;
+
+        try
+        {
+            var dataObj = System.Runtime.InteropServices.Marshal.GetObjectForIUnknown(docData);
+            if (dataObj is IVsTextBuffer vsBuffer)
+            {
+                var adapters = sp.GetService(typeof(SComponentModel)) as Microsoft.VisualStudio.ComponentModelHost.IComponentModel;
+                var factory = adapters?.GetService<IVsEditorAdaptersFactoryService>();
+                return factory?.GetDataBuffer(vsBuffer);
+            }
+        }
+        finally
+        {
+            System.Runtime.InteropServices.Marshal.Release(docData);
+        }
+        return null;
+    }
+
+    /// <summary>Translate a 1-based <see cref="FileRange"/> into a 0-based (start, length) pair over raw text.</summary>
+    public static (int Start, int Length) ToOffsets(string text, FileRange range)
+    {
+        var lineStarts = new List<int> { 0 };
+        for (int i = 0; i < text.Length; i++)
+            if (text[i] == '\n') lineStarts.Add(i + 1);
+
+        int LineLen(int idx)
+        {
+            int s = lineStarts[idx];
+            int e = idx + 1 < lineStarts.Count ? lineStarts[idx + 1] : text.Length;
+            int len = e - s;
+            if (len > 0 && text[s + len - 1] == '\n') { len--; if (len > 0 && text[s + len - 1] == '\r') len--; }
+            return len;
+        }
+
+        int startLine = Math.Max(1, range.StartLine) - 1;
+        int endLine = Math.Max(startLine + 1, range.EndLine) - 1;
+        if (startLine >= lineStarts.Count) startLine = lineStarts.Count - 1;
+        if (endLine >= lineStarts.Count) endLine = lineStarts.Count - 1;
+
+        int startCol = Math.Min(LineLen(startLine), Math.Max(1, range.StartColumn) - 1);
+        int endCol = Math.Min(LineLen(endLine), Math.Max(1, range.EndColumn) - 1);
+
+        int start = lineStarts[startLine] + startCol;
+        int end = lineStarts[endLine] + endCol;
+        if (end < start) end = start;
+        return (start, end - start);
+    }
+
+    /// <summary>Translate a 1-based <see cref="FileRange"/> into a 0-based <see cref="Microsoft.VisualStudio.Text.Span"/> against a snapshot.</summary>
+    public static Microsoft.VisualStudio.Text.Span ToSpan(Microsoft.VisualStudio.Text.ITextSnapshot snapshot, FileRange range)
+    {
+        int startLine = Math.Max(1, range.StartLine) - 1;
+        int endLine = Math.Max(startLine + 1, range.EndLine) - 1;
+        if (startLine >= snapshot.LineCount) startLine = snapshot.LineCount - 1;
+        if (endLine >= snapshot.LineCount) endLine = snapshot.LineCount - 1;
+
+        var startLineObj = snapshot.GetLineFromLineNumber(startLine);
+        var endLineObj = snapshot.GetLineFromLineNumber(endLine);
+
+        int startCol = Math.Min(startLineObj.Length, Math.Max(1, range.StartColumn) - 1);
+        int endCol = Math.Min(endLineObj.Length, Math.Max(1, range.EndColumn) - 1);
+
+        int start = startLineObj.Start.Position + startCol;
+        int end = endLineObj.Start.Position + endCol;
+        if (end < start) end = start;
+        return Microsoft.VisualStudio.Text.Span.FromBounds(start, end);
+    }
+}
+
+internal sealed class VsmcpException : Exception
+{
+    public string Code { get; }
+    public VsmcpException(string code, string message) : base($"{code}: {message}") => Code = code;
+    public VsmcpException(string code, string message, Exception inner) : base($"{code}: {message}", inner) => Code = code;
+}


### PR DESCRIPTION
## Summary
- Implements milestone **M2** from [DesignDoc.md](../blob/main/DesignDoc.md) §5.2 — the ~10% project/file/edit surface that precedes the debug & diagnostics work.
- 18 new RPC methods on \`IVsmcpRpc\` (solution.*, project.*, file.*, editor.*), wired through to Claude via \`[McpServerTool]\` wrappers in \`VsmcpTools\`.
- File writes route through \`ITextBuffer\` when the target is open in the editor, so VS undo/redo stays coherent.

## Tool surface
| Group | Tools |
|---|---|
| Solution | \`solution.info\`, \`solution.open\`, \`solution.close\` |
| Project | \`project.list\`, \`project.add\`, \`project.remove\`, \`project.properties.get\`, \`project.properties.set\`, \`project.file.add\`, \`project.file.remove\`, \`project.folder.create\` |
| File/editor | \`file.read\`, \`file.write\`, \`file.replace_range\`, \`editor.open\`, \`editor.save\`, \`editor.save_all\` |

## Test plan
- [ ] Launch Experimental instance, open a solution, call \`solution.info\` — Projects list matches Solution Explorer.
- [ ] \`project.list\` enumerates through solution folders.
- [ ] \`project.file.add\` with \`linkOnly=false\` copies into the project and adds the item.
- [ ] \`file.write\` on an open document updates the buffer (dirty marker appears; Ctrl+Z undoes the edit).
- [ ] \`file.replace_range\` with a 1-based range matches the VS editor selection.
- [ ] \`editor.open\` with line/column moves the caret.
- [ ] \`editor.save_all\` saves every dirty document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)