### PR TITLE
M3: Build tool surface

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -235,4 +235,104 @@ public sealed class VsmcpTools
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         await proxy.EditorSaveAllAsync(ct).ConfigureAwait(false);
     }
+
+    // -------- Build --------
+
+    [McpServerTool(Name = "build.start")]
+    [Description("Start building the current solution (or a subset of projects). Returns immediately with a buildId. Poll build.status or call build.wait.")]
+    public async Task<BuildHandle> BuildStart(
+        [Description("Solution configuration name (e.g. 'Debug', 'Release'). Omit to use the active configuration.")] string? configuration = null,
+        [Description("Target platform (e.g. 'Any CPU', 'x64'). Omit to use the active platform.")] string? platform = null,
+        [Description("Optional project ids (UniqueName/Name/FullPath) to limit the build. Omit to build the whole solution.")] IReadOnlyList<string>? projectIds = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildStartAsync(configuration, platform, projectIds, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "build.rebuild")]
+    [Description("Clean then build the solution (or selected projects). Returns a buildId to poll.")]
+    public async Task<BuildHandle> BuildRebuild(
+        [Description("Solution configuration name.")] string? configuration = null,
+        [Description("Target platform.")] string? platform = null,
+        [Description("Optional project ids to limit the rebuild.")] IReadOnlyList<string>? projectIds = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildRebuildAsync(configuration, platform, projectIds, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "build.clean")]
+    [Description("Clean the solution (or selected projects). Returns a buildId for parity with build.start.")]
+    public async Task<BuildHandle> BuildClean(
+        [Description("Solution configuration name.")] string? configuration = null,
+        [Description("Target platform.")] string? platform = null,
+        [Description("Optional project ids to limit the clean.")] IReadOnlyList<string>? projectIds = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildCleanAsync(configuration, platform, projectIds, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "build.status")]
+    [Description("Current status of a build started via build.start / build.rebuild / build.clean.")]
+    public async Task<BuildStatus> BuildStatusQuery(
+        [Description("Build id returned from build.start.")] string buildId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildStatusAsync(buildId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "build.wait")]
+    [Description("Block until the build reaches a terminal state or the timeout elapses. Returns TimedOut status cleanly when the timer wins.")]
+    public async Task<BuildStatus> BuildWait(
+        [Description("Build id returned from build.start.")] string buildId,
+        [Description("Max milliseconds to wait. Omit or set to 0 for no timeout.")] int? timeoutMs = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildWaitAsync(buildId, timeoutMs is > 0 ? timeoutMs : null, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "build.cancel")]
+    [Description("Request cancellation of an in-flight build.")]
+    public async Task<BuildStatus> BuildCancel(
+        [Description("Build id returned from build.start.")] string buildId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildCancelAsync(buildId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "build.errors")]
+    [Description("Errors (severity=Error) produced by a build. Valid after the build has reached a terminal state.")]
+    public async Task<IReadOnlyList<BuildDiagnostic>> BuildErrors(
+        [Description("Build id returned from build.start.")] string buildId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildErrorsAsync(buildId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "build.warnings")]
+    [Description("Warnings (severity=Warning) produced by a build. Valid after the build has reached a terminal state.")]
+    public async Task<IReadOnlyList<BuildDiagnostic>> BuildWarnings(
+        [Description("Build id returned from build.start.")] string buildId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildWarningsAsync(buildId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "build.output")]
+    [Description("Raw text captured from an Output window pane (defaults to the Build pane) for a completed build.")]
+    public async Task<BuildOutput> BuildOutputText(
+        [Description("Build id returned from build.start.")] string buildId,
+        [Description("Output window pane name. Defaults to 'Build'.")] string? pane = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BuildOutputAsync(buildId, pane, ct).ConfigureAwait(false);
+    }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -38,4 +38,15 @@ public interface IVsmcpRpc
     Task EditorOpenAsync(string path, int? line, int? column, CancellationToken cancellationToken = default);
     Task EditorSaveAsync(string path, CancellationToken cancellationToken = default);
     Task EditorSaveAllAsync(CancellationToken cancellationToken = default);
+
+    // -------- Build --------
+    Task<BuildHandle> BuildStartAsync(string? configuration, string? platform, IReadOnlyList<string>? projectIds, CancellationToken cancellationToken = default);
+    Task<BuildHandle> BuildRebuildAsync(string? configuration, string? platform, IReadOnlyList<string>? projectIds, CancellationToken cancellationToken = default);
+    Task<BuildHandle> BuildCleanAsync(string? configuration, string? platform, IReadOnlyList<string>? projectIds, CancellationToken cancellationToken = default);
+    Task<BuildStatus> BuildStatusAsync(string buildId, CancellationToken cancellationToken = default);
+    Task<BuildStatus> BuildWaitAsync(string buildId, int? timeoutMs, CancellationToken cancellationToken = default);
+    Task<BuildStatus> BuildCancelAsync(string buildId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<BuildDiagnostic>> BuildErrorsAsync(string buildId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<BuildDiagnostic>> BuildWarningsAsync(string buildId, CancellationToken cancellationToken = default);
+    Task<BuildOutput> BuildOutputAsync(string buildId, string? pane, CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M3Dtos.cs
+++ b/src/VSMCP.Shared/M3Dtos.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public enum BuildAction
+{
+    Build = 0,
+    Rebuild = 1,
+    Clean = 2,
+}
+
+public enum BuildState
+{
+    Queued = 0,
+    Running = 1,
+    Succeeded = 2,
+    Failed = 3,
+    Canceled = 4,
+    TimedOut = 5,
+}
+
+public enum BuildSeverity
+{
+    Info = 0,
+    Warning = 1,
+    Error = 2,
+}
+
+public sealed class BuildHandle
+{
+    /// <summary>Opaque id for later status/wait/cancel/errors calls.</summary>
+    public string BuildId { get; set; } = "";
+    public BuildAction Action { get; set; }
+    public string? Configuration { get; set; }
+    public string? Platform { get; set; }
+    public List<string> Projects { get; set; } = new();
+    public long StartedAtMs { get; set; }
+}
+
+public sealed class BuildStatus
+{
+    public string BuildId { get; set; } = "";
+    public BuildState State { get; set; }
+    public long StartedAtMs { get; set; }
+    public long? EndedAtMs { get; set; }
+    public int ErrorCount { get; set; }
+    public int WarningCount { get; set; }
+    /// <summary>True if every project reported success. Populated when State is terminal.</summary>
+    public bool? AllProjectsSucceeded { get; set; }
+}
+
+public sealed class BuildDiagnostic
+{
+    public BuildSeverity Severity { get; set; }
+    public string? Code { get; set; }
+    public string Message { get; set; } = "";
+    public string? Project { get; set; }
+    public string? File { get; set; }
+    public int? Line { get; set; }
+    public int? Column { get; set; }
+}
+
+public sealed class BuildOutput
+{
+    public string BuildId { get; set; } = "";
+    /// <summary>Name of the Output window pane the text came from (typically "Build").</summary>
+    public string Pane { get; set; } = "Build";
+    public string Text { get; set; } = "";
+}

--- a/src/VSMCP.Vsix/BuildCoordinator.cs
+++ b/src/VSMCP.Vsix/BuildCoordinator.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// Tracks async solution builds started via <see cref="RpcTarget"/> so callers can poll
+/// status, block on <see cref="WaitAsync"/>, or ask for diagnostics after completion.
+///
+/// Instances subscribe to <see cref="IVsUpdateSolutionEvents2"/> for the lifetime of a
+/// build and self-unadvise when it ends.
+/// </summary>
+internal sealed class BuildCoordinator
+{
+    private readonly ConcurrentDictionary<string, BuildJob> _builds = new();
+
+    public BuildJob Register(BuildAction action, string? configuration, string? platform, IReadOnlyList<string>? projects)
+    {
+        var job = new BuildJob
+        {
+            Handle = new BuildHandle
+            {
+                BuildId = Guid.NewGuid().ToString("N"),
+                Action = action,
+                Configuration = configuration,
+                Platform = platform,
+                Projects = projects is null ? new List<string>() : new List<string>(projects),
+                StartedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            },
+            State = BuildState.Queued,
+            Completion = new TaskCompletionSource<BuildStatus>(TaskCreationOptions.RunContinuationsAsynchronously),
+        };
+        _builds[job.Handle.BuildId] = job;
+        return job;
+    }
+
+    public BuildJob Require(string buildId)
+    {
+        if (!_builds.TryGetValue(buildId, out var job))
+            throw new VsmcpException(ErrorCodes.NotFound, $"Unknown buildId '{buildId}'.");
+        return job;
+    }
+
+    public bool TryGet(string buildId, out BuildJob job) => _builds.TryGetValue(buildId, out job!);
+
+    public BuildStatus Snapshot(BuildJob job) => new()
+    {
+        BuildId = job.Handle.BuildId,
+        State = job.State,
+        StartedAtMs = job.Handle.StartedAtMs,
+        EndedAtMs = job.EndedAtMs,
+        ErrorCount = job.Errors.Count,
+        WarningCount = job.Warnings.Count,
+        AllProjectsSucceeded = job.State switch
+        {
+            BuildState.Succeeded => true,
+            BuildState.Failed => false,
+            _ => null,
+        },
+    };
+
+    public void MarkRunning(BuildJob job)
+    {
+        job.State = BuildState.Running;
+    }
+
+    public void MarkCompleted(BuildJob job, BuildState finalState)
+    {
+        job.State = finalState;
+        job.EndedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        job.Completion.TrySetResult(Snapshot(job));
+    }
+
+    public async Task<BuildStatus> WaitAsync(BuildJob job, int? timeoutMs, CancellationToken ct)
+    {
+        if (job.Completion.Task.IsCompleted)
+            return job.Completion.Task.Result;
+
+        if (timeoutMs is null)
+        {
+            using var reg = ct.Register(() => job.Completion.TrySetCanceled(ct));
+            return await job.Completion.Task.ConfigureAwait(false);
+        }
+
+        var delay = Task.Delay(timeoutMs.Value, ct);
+        var winner = await Task.WhenAny(job.Completion.Task, delay).ConfigureAwait(false);
+        if (winner == job.Completion.Task)
+            return await job.Completion.Task.ConfigureAwait(false);
+
+        var snap = Snapshot(job);
+        snap.State = BuildState.TimedOut;
+        return snap;
+    }
+}
+
+internal sealed class BuildJob : IVsUpdateSolutionEvents2
+{
+    public BuildHandle Handle { get; set; } = null!;
+    public BuildState State { get; set; }
+    public long? EndedAtMs { get; set; }
+    public TaskCompletionSource<BuildStatus> Completion { get; set; } = null!;
+    public List<BuildDiagnostic> Errors { get; } = new();
+    public List<BuildDiagnostic> Warnings { get; } = new();
+    /// <summary>Output-pane text captured after the build finishes.</summary>
+    public string OutputText { get; set; } = "";
+
+    public uint AdviseCookie { get; set; }
+    public IVsSolutionBuildManager2? BuildManager { get; set; }
+
+    // -------- IVsUpdateSolutionEvents2 --------
+
+    public int UpdateSolution_Begin(ref int pfCancelUpdate) => 0;
+
+    public int UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
+    {
+        var final = fCancelCommand != 0 ? BuildState.Canceled
+                  : fSucceeded != 0 ? BuildState.Succeeded
+                  : BuildState.Failed;
+        State = final;
+        EndedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        // Coordinator completes the TCS after it collects diagnostics; just record the result here.
+        return 0;
+    }
+
+    public int UpdateSolution_StartUpdate(ref int pfCancelUpdate) => 0;
+    public int UpdateSolution_Cancel() => 0;
+    public int OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy) => 0;
+    public int UpdateProjectCfg_Begin(IVsHierarchy pHierProj, IVsCfg pCfgProj, IVsCfg pCfgSln, uint dwAction, ref int pfCancel) => 0;
+    public int UpdateProjectCfg_Done(IVsHierarchy pHierProj, IVsCfg pCfgProj, IVsCfg pCfgSln, uint dwAction, int fSuccess, int fCancel) => 0;
+}

--- a/src/VSMCP.Vsix/RpcTarget.Build.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Build.cs
@@ -1,0 +1,283 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    private readonly BuildCoordinator _builds = new();
+
+    public Task<BuildHandle> BuildStartAsync(string? configuration, string? platform, IReadOnlyList<string>? projectIds, CancellationToken cancellationToken = default)
+        => StartBuildAsync(BuildAction.Build, configuration, platform, projectIds, cancellationToken);
+
+    public Task<BuildHandle> BuildRebuildAsync(string? configuration, string? platform, IReadOnlyList<string>? projectIds, CancellationToken cancellationToken = default)
+        => StartBuildAsync(BuildAction.Rebuild, configuration, platform, projectIds, cancellationToken);
+
+    public Task<BuildHandle> BuildCleanAsync(string? configuration, string? platform, IReadOnlyList<string>? projectIds, CancellationToken cancellationToken = default)
+        => StartBuildAsync(BuildAction.Clean, configuration, platform, projectIds, cancellationToken);
+
+    private async Task<BuildHandle> StartBuildAsync(BuildAction action, string? configuration, string? platform, IReadOnlyList<string>? projectIds, CancellationToken ct)
+    {
+        await _jtf.SwitchToMainThreadAsync(ct);
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+
+        var solution = dte.Solution;
+        if (solution?.IsOpen != true)
+            throw new VsmcpException(ErrorCodes.WrongState, "No solution is open.");
+
+        var sb = solution.SolutionBuild
+            ?? throw new VsmcpException(ErrorCodes.InteropFault, "SolutionBuild unavailable.");
+
+        if (!string.IsNullOrWhiteSpace(configuration))
+            ActivateConfiguration(sb, configuration!, platform);
+
+        var job = _builds.Register(action, configuration, platform, projectIds);
+
+        var bm = await _package.GetServiceAsync(typeof(SVsSolutionBuildManager)) as IVsSolutionBuildManager2
+            ?? throw new VsmcpException(ErrorCodes.InteropFault, "IVsSolutionBuildManager2 unavailable.");
+
+        job.BuildManager = bm;
+        ErrorHandler.ThrowOnFailure(bm.AdviseUpdateSolutionEvents(job, out var cookie));
+        job.AdviseCookie = cookie;
+
+        _builds.MarkRunning(job);
+
+        try
+        {
+            if (projectIds is { Count: > 0 })
+            {
+                var cfgName = configuration ?? TryGetActiveConfigName(sb) ?? "Debug";
+                foreach (var id in projectIds)
+                {
+                    var project = VsHelpers.RequireProject(solution, id);
+                    var unique = project.UniqueName;
+                    switch (action)
+                    {
+                        case BuildAction.Clean:
+                            sb.BuildProject(cfgName, unique, WaitForBuildToFinish: false);
+                            sb.Clean(WaitForCleanToFinish: false);
+                            break;
+                        case BuildAction.Rebuild:
+                            sb.Clean(WaitForCleanToFinish: true);
+                            sb.BuildProject(cfgName, unique, WaitForBuildToFinish: false);
+                            break;
+                        default:
+                            sb.BuildProject(cfgName, unique, WaitForBuildToFinish: false);
+                            break;
+                    }
+                }
+            }
+            else
+            {
+                switch (action)
+                {
+                    case BuildAction.Clean: sb.Clean(WaitForCleanToFinish: false); break;
+                    case BuildAction.Rebuild: sb.Clean(WaitForCleanToFinish: true); sb.Build(WaitForBuildToFinish: false); break;
+                    default: sb.Build(WaitForBuildToFinish: false); break;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            UnadviseAndComplete(job, BuildState.Failed);
+            throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to start build: {ex.Message}", ex);
+        }
+
+        return job.Handle;
+    }
+
+    public async Task<BuildStatus> BuildStatusAsync(string buildId, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var job = _builds.Require(buildId);
+        MaybeFinalize(job);
+        return _builds.Snapshot(job);
+    }
+
+    public async Task<BuildStatus> BuildWaitAsync(string buildId, int? timeoutMs, CancellationToken cancellationToken = default)
+    {
+        var job = _builds.Require(buildId);
+        var status = await _builds.WaitAsync(job, timeoutMs, cancellationToken).ConfigureAwait(false);
+
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        MaybeFinalize(job);
+        return _builds.Snapshot(job);
+    }
+
+    public async Task<BuildStatus> BuildCancelAsync(string buildId, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var job = _builds.Require(buildId);
+
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is EnvDTE80.DTE2 dte)
+        {
+            try { dte.ExecuteCommand("Build.Cancel"); } catch { }
+        }
+        // UpdateSolution_Done with fCancelCommand=1 will transition state.
+        return _builds.Snapshot(job);
+    }
+
+    public async Task<IReadOnlyList<BuildDiagnostic>> BuildErrorsAsync(string buildId, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var job = _builds.Require(buildId);
+        MaybeFinalize(job);
+        return job.Errors.AsReadOnly();
+    }
+
+    public async Task<IReadOnlyList<BuildDiagnostic>> BuildWarningsAsync(string buildId, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var job = _builds.Require(buildId);
+        MaybeFinalize(job);
+        return job.Warnings.AsReadOnly();
+    }
+
+    public async Task<BuildOutput> BuildOutputAsync(string buildId, string? pane, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var job = _builds.Require(buildId);
+        MaybeFinalize(job);
+
+        var paneName = string.IsNullOrWhiteSpace(pane) ? "Build" : pane!;
+        string text = job.OutputText;
+        if (string.IsNullOrEmpty(text))
+            text = TryReadOutputPane(paneName) ?? "";
+
+        return new BuildOutput { BuildId = buildId, Pane = paneName, Text = text };
+    }
+
+    // -------- helpers --------
+
+    private void MaybeFinalize(BuildJob job)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (job.Completion.Task.IsCompleted) return;
+        if (job.State is BuildState.Queued or BuildState.Running) return;
+
+        CollectDiagnostics(job);
+        job.OutputText = TryReadOutputPane("Build") ?? "";
+        UnadviseAndComplete(job, job.State);
+    }
+
+    private void UnadviseAndComplete(BuildJob job, BuildState finalState)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (job.BuildManager is { } bm && job.AdviseCookie != 0)
+        {
+            try { bm.UnadviseUpdateSolutionEvents(job.AdviseCookie); } catch { }
+            job.AdviseCookie = 0;
+        }
+        _builds.MarkCompleted(job, finalState);
+    }
+
+    private void CollectDiagnostics(BuildJob job)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        EnvDTE80.DTE2? dte = null;
+        try { dte = ServiceProvider.GlobalProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE80.DTE2; } catch { }
+        if (dte is null) return;
+
+        try
+        {
+            var errorList = dte.ToolWindows.ErrorList;
+            if (errorList?.ErrorItems is null) return;
+
+            for (int i = 1; i <= errorList.ErrorItems.Count; i++)
+            {
+                EnvDTE80.ErrorItem item;
+                try { item = errorList.ErrorItems.Item(i); } catch { continue; }
+                if (item is null) continue;
+
+                var severity = item.ErrorLevel switch
+                {
+                    EnvDTE80.vsBuildErrorLevel.vsBuildErrorLevelHigh => BuildSeverity.Error,
+                    EnvDTE80.vsBuildErrorLevel.vsBuildErrorLevelMedium => BuildSeverity.Warning,
+                    _ => BuildSeverity.Info,
+                };
+
+                string? file = null, project = null, description = null;
+                int? line = null, col = null;
+                try { file = item.FileName; } catch { }
+                try { project = item.Project; } catch { }
+                try { description = item.Description; } catch { }
+                try { line = item.Line > 0 ? item.Line : null; } catch { }
+                try { col = item.Column > 0 ? item.Column : null; } catch { }
+
+                var diag = new BuildDiagnostic
+                {
+                    Severity = severity,
+                    Message = description ?? "",
+                    Project = string.IsNullOrEmpty(project) ? null : project,
+                    File = string.IsNullOrEmpty(file) ? null : file,
+                    Line = line,
+                    Column = col,
+                };
+
+                if (severity == BuildSeverity.Error) job.Errors.Add(diag);
+                else if (severity == BuildSeverity.Warning) job.Warnings.Add(diag);
+            }
+        }
+        catch { }
+    }
+
+    private string? TryReadOutputPane(string paneName)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            var dte = ServiceProvider.GlobalProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE80.DTE2;
+            var panes = dte?.ToolWindows.OutputWindow.OutputWindowPanes;
+            if (panes is null) return null;
+
+            EnvDTE.OutputWindowPane? pane = null;
+            try { pane = panes.Item(paneName); } catch { }
+            if (pane is null) return null;
+
+            var doc = pane.TextDocument;
+            var point = doc.StartPoint.CreateEditPoint();
+            return point.GetText(doc.EndPoint);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void ActivateConfiguration(EnvDTE.SolutionBuild sb, string configuration, string? platform)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            for (int i = 1; i <= sb.SolutionConfigurations.Count; i++)
+            {
+                var cfg = sb.SolutionConfigurations.Item(i) as EnvDTE80.SolutionConfiguration2;
+                if (cfg is null) continue;
+                if (!string.Equals(cfg.Name, configuration, StringComparison.OrdinalIgnoreCase)) continue;
+                if (platform is not null && !string.Equals(cfg.PlatformName, platform, StringComparison.OrdinalIgnoreCase)) continue;
+                cfg.Activate();
+                return;
+            }
+        }
+        catch { }
+    }
+
+    private static string? TryGetActiveConfigName(EnvDTE.SolutionBuild sb)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            return (sb.ActiveConfiguration as EnvDTE80.SolutionConfiguration2)?.Name;
+        }
+        catch { return null; }
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -65,6 +65,8 @@
     <Compile Include="RpcTarget.Solution.cs" />
     <Compile Include="RpcTarget.Project.cs" />
     <Compile Include="RpcTarget.Files.cs" />
+    <Compile Include="RpcTarget.Build.cs" />
+    <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Implements milestone **M3** — drives the VS build pipeline and returns structured results to Claude.
- Async build model: \`build.start\` / \`build.rebuild\` / \`build.clean\` return immediately with a \`buildId\`; poll with \`build.status\` or block with \`build.wait(timeoutMs)\`.
- Build event wiring via \`IVsUpdateSolutionEvents2\` (not polling); diagnostics read from the Error List; raw pane text captured from the Output window's Build pane.

## Tool surface
| Tool | Purpose |
|---|---|
| \`build.start\` | Start a build; returns \`buildId\` |
| \`build.rebuild\` | Clean + build |
| \`build.clean\` | Clean only |
| \`build.status\` | Current \`BuildState\` + error/warning counts |
| \`build.wait\` | Block until terminal; returns \`TimedOut\` cleanly |
| \`build.cancel\` | Cancel via \`Build.Cancel\` command |
| \`build.errors\` / \`build.warnings\` | Structured diagnostics with file/line/col |
| \`build.output\` | Raw Output pane text (defaults to \"Build\") |

## Test plan
- [ ] \`build.start\` on a clean solution → status goes Queued → Running → Succeeded.
- [ ] Introduce a compile error → \`build.errors\` returns items with file/line/column/severity=Error.
- [ ] \`build.cancel\` on a mid-build run returns within ~2s with State=Canceled.
- [ ] \`build.wait\` with a 500ms timeout on a long build returns State=TimedOut without throwing.
- [ ] \`build.output\` returns non-empty text after a completed build.
- [ ] \`project.list\`-derived ids work as the \`projectIds\` filter for \`build.start\`.

Closes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)