### PR TITLE
M4: Debug control — launch, attach, step, continue

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -335,4 +335,131 @@ public sealed class VsmcpTools
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.BuildOutputAsync(buildId, pane, ct).ConfigureAwait(false);
     }
+
+    // -------- Debug control --------
+
+    [McpServerTool(Name = "debug.launch")]
+    [Description("Start a debug session for a project (or the solution's startup project). Returns immediately; poll debug.state to track the transition.")]
+    public async Task<DebugActionResult> DebugLaunch(
+        [Description("Project id (UniqueName/Name/FullPath). Omit for the configured startup project.")] string? projectId = null,
+        [Description("Override command-line arguments.")] string? args = null,
+        [Description("Environment variables to layer on top of the project's configured values.")] Dictionary<string, string>? env = null,
+        [Description("Override the working directory.")] string? cwd = null,
+        [Description("Start without the debugger (equivalent to Ctrl+F5).")] bool noDebug = false,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugLaunchAsync(
+            new DebugLaunchOptions { ProjectId = projectId, Args = args, Env = env, Cwd = cwd, NoDebug = noDebug },
+            ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.attach")]
+    [Description("Attach the VS debugger to an already-running process by pid or name.")]
+    public async Task<DebugActionResult> DebugAttach(
+        [Description("Process id. Either pid or processName must be provided.")] int? pid = null,
+        [Description("Process name without extension (case-insensitive). First match wins.")] string? processName = null,
+        [Description("Optional debug engine names (e.g. 'Managed (.NET Core)', 'Native'). Omit to let VS pick.")] List<string>? engines = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugAttachAsync(
+            new DebugAttachOptions { Pid = pid, ProcessName = processName, Engines = engines },
+            ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.stop")]
+    [Description("Terminate the debuggee and return to design mode.")]
+    public async Task<DebugActionResult> DebugStop(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugStopAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.detach")]
+    [Description("Detach from all debuggees without terminating them.")]
+    public async Task<DebugActionResult> DebugDetach(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugDetachAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.restart")]
+    [Description("Restart the current debug session.")]
+    public async Task<DebugActionResult> DebugRestart(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugRestartAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.break_all")]
+    [Description("Break into all threads and enter break mode.")]
+    public async Task<DebugActionResult> DebugBreakAll(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugBreakAllAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.continue")]
+    [Description("Resume execution from break mode.")]
+    public async Task<DebugActionResult> DebugContinue(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugContinueAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.step_into")]
+    [Description("Step into the next call on the current thread.")]
+    public async Task<DebugActionResult> DebugStepInto(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugStepIntoAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.step_over")]
+    [Description("Step over the next statement, treating calls as atomic.")]
+    public async Task<DebugActionResult> DebugStepOver(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugStepOverAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.step_out")]
+    [Description("Run until the current function returns.")]
+    public async Task<DebugActionResult> DebugStepOut(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugStepOutAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.run_to_cursor")]
+    [Description("Resume execution and break when the specified line is about to execute.")]
+    public async Task<DebugActionResult> DebugRunToCursor(
+        [Description("Absolute path of the file containing the target line.")] string file,
+        [Description("1-based line number to run to.")] int line,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugRunToCursorAsync(file, line, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.set_next_statement")]
+    [Description("Move the instruction pointer to a different line. Requires Break mode and explicit allowSideEffects=true; can corrupt program state.")]
+    public async Task<DebugActionResult> DebugSetNextStatement(
+        [Description("Absolute path of the file.")] string file,
+        [Description("1-based line to jump to. Must be in the current function.")] int line,
+        [Description("Must be true. Acknowledges that constructors/resources may be skipped.")] bool allowSideEffects = false,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugSetNextStatementAsync(file, line, allowSideEffects, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.state")]
+    [Description("Snapshot of the debugger: mode, stopped reason, current process/thread/frame, last exception if any.")]
+    public async Task<DebugInfo> DebugState(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugStateAsync(ct).ConfigureAwait(false);
+    }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -49,4 +49,19 @@ public interface IVsmcpRpc
     Task<IReadOnlyList<BuildDiagnostic>> BuildErrorsAsync(string buildId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<BuildDiagnostic>> BuildWarningsAsync(string buildId, CancellationToken cancellationToken = default);
     Task<BuildOutput> BuildOutputAsync(string buildId, string? pane, CancellationToken cancellationToken = default);
+
+    // -------- Debug control --------
+    Task<DebugActionResult> DebugLaunchAsync(DebugLaunchOptions options, CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugAttachAsync(DebugAttachOptions options, CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugStopAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugDetachAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugRestartAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugBreakAllAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugContinueAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugStepIntoAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugStepOverAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugStepOutAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugRunToCursorAsync(string file, int line, CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugSetNextStatementAsync(string file, int line, bool allowSideEffects, CancellationToken cancellationToken = default);
+    Task<DebugInfo> DebugStateAsync(CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M4Dtos.cs
+++ b/src/VSMCP.Shared/M4Dtos.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+/// <summary>
+/// High-level debug mode, mirroring <c>EnvDTE.dbgDebugMode</c> without leaking the interop type.
+/// </summary>
+public enum DebugMode
+{
+    Design = 0,
+    Break = 1,
+    Run = 2,
+}
+
+/// <summary>
+/// Why the debugger is stopped. Populated only when <see cref="DebugInfo.Mode"/> is <see cref="DebugMode.Break"/>.
+/// </summary>
+public enum DebugStoppedReason
+{
+    Unknown = 0,
+    UserBreak = 1,
+    Breakpoint = 2,
+    Step = 3,
+    Exception = 4,
+    Terminated = 5,
+}
+
+public sealed class DebugLaunchOptions
+{
+    /// <summary>Project id (UniqueName, Name, or full path). Omit to debug the solution's configured startup project.</summary>
+    public string? ProjectId { get; set; }
+    /// <summary>Override the startup project's command-line arguments. Omit to keep the configured value.</summary>
+    public string? Args { get; set; }
+    /// <summary>Environment variables to layer on top of the startup project's environment.</summary>
+    public Dictionary<string, string>? Env { get; set; }
+    /// <summary>Override the working directory. Omit to keep the configured value.</summary>
+    public string? Cwd { get; set; }
+    /// <summary>When true, start without attaching a debugger (F5 vs Ctrl+F5).</summary>
+    public bool NoDebug { get; set; }
+}
+
+public sealed class DebugAttachOptions
+{
+    /// <summary>Process id to attach to. Exactly one of <see cref="Pid"/> or <see cref="ProcessName"/> must be set.</summary>
+    public int? Pid { get; set; }
+    /// <summary>Process name (matched case-insensitively against <c>Process.Name</c>). First match wins.</summary>
+    public string? ProcessName { get; set; }
+    /// <summary>
+    /// Optional debug-engine names (e.g. "Managed (.NET Core)", "Native", "Python"). Empty or null
+    /// lets VS pick automatically.
+    /// </summary>
+    public List<string>? Engines { get; set; }
+}
+
+public sealed class DebugThreadInfo
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public bool IsCurrent { get; set; }
+}
+
+public sealed class DebugFrameInfo
+{
+    public int Index { get; set; }
+    public string FunctionName { get; set; } = "";
+    public string? File { get; set; }
+    public int? Line { get; set; }
+    public int? Column { get; set; }
+    public string? Language { get; set; }
+}
+
+public sealed class DebugInfo
+{
+    public DebugMode Mode { get; set; }
+    public DebugStoppedReason StoppedReason { get; set; }
+    public int? CurrentProcessId { get; set; }
+    public string? CurrentProcessName { get; set; }
+    public DebugThreadInfo? CurrentThread { get; set; }
+    public DebugFrameInfo? CurrentFrame { get; set; }
+    /// <summary>Last exception description, when <see cref="StoppedReason"/> is <see cref="DebugStoppedReason.Exception"/>.</summary>
+    public string? LastExceptionMessage { get; set; }
+}
+
+public sealed class DebugActionResult
+{
+    /// <summary>Post-action debug info snapshot. Callers typically use this to confirm the transition.</summary>
+    public DebugInfo Info { get; set; } = new();
+    /// <summary>Human-readable note about the action (e.g. "Attached to pid 12345").</summary>
+    public string? Note { get; set; }
+}

--- a/src/VSMCP.Vsix/RpcTarget.Debug.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Debug.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public async Task<DebugActionResult> DebugLaunchAsync(DebugLaunchOptions options, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+
+        var sb = dte.Solution?.SolutionBuild
+            ?? throw new VsmcpException(ErrorCodes.WrongState, "No solution is open.");
+
+        string? previousStartup = null;
+        if (!string.IsNullOrWhiteSpace(options.ProjectId))
+        {
+            try
+            {
+                if (sb.StartupProjects is Array arr && arr.Length > 0 && arr.GetValue(0) is string sp)
+                    previousStartup = sp;
+            }
+            catch { }
+
+            var project = VsHelpers.RequireProject(dte.Solution, options.ProjectId!);
+            try { sb.StartupProjects = project.UniqueName; } catch { }
+
+            if (options.Args is not null || options.Cwd is not null || options.Env is not null)
+                ApplyLaunchProperties(project, options);
+        }
+
+        try
+        {
+            if (options.NoDebug)
+                sb.Run();
+            else
+                dte.Debugger.Go(WaitForBreakOrEnd: false);
+        }
+        catch (Exception ex)
+        {
+            throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to launch: {ex.Message}", ex);
+        }
+
+        return Result("Debug session started.", options.ProjectId is null ? null : $"startup={options.ProjectId}");
+    }
+
+    public async Task<DebugActionResult> DebugAttachAsync(DebugAttachOptions options, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+
+        if (options.Pid is null && string.IsNullOrWhiteSpace(options.ProcessName))
+            throw new VsmcpException(ErrorCodes.NotFound, "Either Pid or ProcessName must be supplied.");
+
+        var debugger = dte.Debugger as EnvDTE80.Debugger2
+            ?? throw new VsmcpException(ErrorCodes.InteropFault, "Debugger2 interface unavailable.");
+
+        EnvDTE80.Process2? target = null;
+        foreach (EnvDTE.Process p in debugger.LocalProcesses)
+        {
+            if (p is not EnvDTE80.Process2 p2) continue;
+            if (options.Pid is int pid && p2.ProcessID == pid) { target = p2; break; }
+            if (!string.IsNullOrWhiteSpace(options.ProcessName)
+                && string.Equals(Path.GetFileNameWithoutExtension(p2.Name), options.ProcessName, StringComparison.OrdinalIgnoreCase))
+            {
+                target = p2;
+                break;
+            }
+        }
+
+        if (target is null)
+            throw new VsmcpException(ErrorCodes.NotFound,
+                options.Pid is int pid ? $"No local process with pid {pid}." : $"No local process named '{options.ProcessName}'.");
+
+        try
+        {
+            if (options.Engines is { Count: > 0 })
+            {
+                var engines = options.Engines.ToArray();
+                target.Attach2(engines);
+            }
+            else
+            {
+                target.Attach();
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new VsmcpException(ErrorCodes.InteropFault, $"Attach failed: {ex.Message}", ex);
+        }
+
+        return Result("Attached.", $"pid={target.ProcessID}, name={target.Name}");
+    }
+
+    public async Task<DebugActionResult> DebugStopAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try { dte.Debugger.Stop(WaitForDesignMode: false); } catch (Exception ex) { throw Interop("stop", ex); }
+        return Result("Stopped.");
+    }
+
+    public async Task<DebugActionResult> DebugDetachAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try { dte.Debugger.DetachAll(); } catch (Exception ex) { throw Interop("detach", ex); }
+        return Result("Detached.");
+    }
+
+    public async Task<DebugActionResult> DebugRestartAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try
+        {
+            if (dte.Debugger is EnvDTE80.Debugger2 dbg2)
+                dte.ExecuteCommand("Debug.Restart");
+            else
+                dte.Debugger.Stop(WaitForDesignMode: true);
+        }
+        catch (Exception ex) { throw Interop("restart", ex); }
+        return Result("Restart requested.");
+    }
+
+    public async Task<DebugActionResult> DebugBreakAllAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try { dte.Debugger.Break(WaitForBreakMode: false); } catch (Exception ex) { throw Interop("break", ex); }
+        return Result("Break requested.");
+    }
+
+    public async Task<DebugActionResult> DebugContinueAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try { dte.Debugger.Go(WaitForBreakOrEnd: false); } catch (Exception ex) { throw Interop("continue", ex); }
+        return Result("Continued.");
+    }
+
+    public async Task<DebugActionResult> DebugStepIntoAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try { dte.Debugger.StepInto(WaitForBreakOrEnd: false); } catch (Exception ex) { throw Interop("step into", ex); }
+        return Result("Step into.");
+    }
+
+    public async Task<DebugActionResult> DebugStepOverAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try { dte.Debugger.StepOver(WaitForBreakOrEnd: false); } catch (Exception ex) { throw Interop("step over", ex); }
+        return Result("Step over.");
+    }
+
+    public async Task<DebugActionResult> DebugStepOutAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try { dte.Debugger.StepOut(WaitForBreakOrEnd: false); } catch (Exception ex) { throw Interop("step out", ex); }
+        return Result("Step out.");
+    }
+
+    public async Task<DebugActionResult> DebugRunToCursorAsync(string file, int line, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+
+        if (string.IsNullOrWhiteSpace(file)) throw new VsmcpException(ErrorCodes.NotFound, "File is required.");
+        if (!File.Exists(file)) throw new VsmcpException(ErrorCodes.NotFound, $"File not found: {file}");
+
+        MoveCaret(dte, file, line, 1);
+        try { dte.ExecuteCommand("Debug.RunToCursor"); }
+        catch (Exception ex) { throw Interop("run to cursor", ex); }
+        return Result("Run to cursor.", $"{file}:{line}");
+    }
+
+    public async Task<DebugActionResult> DebugSetNextStatementAsync(string file, int line, bool allowSideEffects, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+
+        if (!allowSideEffects)
+            throw new VsmcpException(ErrorCodes.WrongState,
+                "Set-next-statement can skip constructors, leak resources, or corrupt program state. Pass allowSideEffects=true to proceed.");
+        if (string.IsNullOrWhiteSpace(file)) throw new VsmcpException(ErrorCodes.NotFound, "File is required.");
+        if (!File.Exists(file)) throw new VsmcpException(ErrorCodes.NotFound, $"File not found: {file}");
+
+        if (dte.Debugger.CurrentMode != EnvDTE.dbgDebugMode.dbgBreakMode)
+            throw new VsmcpException(ErrorCodes.WrongState, "Debugger must be in Break mode to set next statement.");
+
+        MoveCaret(dte, file, line, 1);
+        try { dte.ExecuteCommand("Debug.SetNextStatement"); }
+        catch (Exception ex) { throw Interop("set next statement", ex); }
+        return Result("Set next statement.", $"{file}:{line}");
+    }
+
+    public async Task<DebugInfo> DebugStateAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        return SnapshotDebugInfo(dte);
+    }
+
+    // -------- helpers --------
+
+    private async Task<EnvDTE80.DTE2> RequireDteAsync()
+    {
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is not EnvDTE80.DTE2 dte)
+            throw new VsmcpException(ErrorCodes.InteropFault, "DTE service unavailable.");
+        return dte;
+    }
+
+    private static DebugActionResult Result(string note, string? detail = null)
+    {
+        var dte = ServiceProvider.GlobalProvider.GetService(typeof(EnvDTE.DTE)) as EnvDTE80.DTE2;
+        return new DebugActionResult
+        {
+            Note = detail is null ? note : $"{note} ({detail})",
+            Info = dte is null ? new DebugInfo() : SnapshotDebugInfo(dte),
+        };
+    }
+
+    private static VsmcpException Interop(string action, Exception ex)
+        => new(ErrorCodes.InteropFault, $"Failed to {action}: {ex.Message}", ex);
+
+    private static DebugInfo SnapshotDebugInfo(EnvDTE80.DTE2 dte)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var info = new DebugInfo { Mode = DebugMode.Design, StoppedReason = DebugStoppedReason.Unknown };
+
+        var debugger = dte.Debugger;
+        if (debugger is null) return info;
+
+        info.Mode = debugger.CurrentMode switch
+        {
+            EnvDTE.dbgDebugMode.dbgBreakMode => DebugMode.Break,
+            EnvDTE.dbgDebugMode.dbgRunMode => DebugMode.Run,
+            _ => DebugMode.Design,
+        };
+
+        try
+        {
+            var currentProcess = debugger.CurrentProcess;
+            if (currentProcess is not null)
+            {
+                info.CurrentProcessId = currentProcess.ProcessID;
+                info.CurrentProcessName = currentProcess.Name;
+            }
+        }
+        catch { }
+
+        if (info.Mode == DebugMode.Break)
+        {
+            info.StoppedReason = DebugStoppedReason.UserBreak;
+            try
+            {
+                var thread = debugger.CurrentThread;
+                if (thread is not null)
+                    info.CurrentThread = new DebugThreadInfo { Id = thread.ID, Name = thread.Name, IsCurrent = true };
+            }
+            catch { }
+
+            try
+            {
+                var frame = debugger.CurrentStackFrame;
+                if (frame is not null)
+                {
+                    var f = new DebugFrameInfo
+                    {
+                        Index = 0,
+                        FunctionName = frame.FunctionName ?? "",
+                        Language = frame.Language,
+                    };
+
+                    try
+                    {
+                        var doc = dte.ActiveDocument;
+                        if (doc?.Selection is EnvDTE.TextSelection sel)
+                        {
+                            f.File = doc.FullName;
+                            f.Line = sel.CurrentLine;
+                            f.Column = sel.CurrentColumn;
+                        }
+                    }
+                    catch { }
+
+                    info.CurrentFrame = f;
+                }
+            }
+            catch { }
+
+            try
+            {
+                var ex = debugger.GetExpression("$exception", true, 200);
+                if (ex is not null && ex.IsValidValue && !string.IsNullOrEmpty(ex.Value))
+                {
+                    info.StoppedReason = DebugStoppedReason.Exception;
+                    info.LastExceptionMessage = ex.Value;
+                }
+            }
+            catch { }
+        }
+
+        return info;
+    }
+
+    private static void MoveCaret(EnvDTE80.DTE2 dte, string file, int line, int column)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var window = dte.ItemOperations.OpenFile(file, EnvDTE.Constants.vsViewKindPrimary);
+        if (window?.Document?.Selection is EnvDTE.TextSelection sel)
+            sel.MoveToLineAndOffset(Math.Max(1, line), Math.Max(1, column));
+    }
+
+    private static void ApplyLaunchProperties(EnvDTE.Project project, DebugLaunchOptions options)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            var cfg = project.ConfigurationManager?.ActiveConfiguration;
+            var props = cfg?.Properties;
+            if (props is null) return;
+
+            TrySet(props, "StartArguments", options.Args);
+            TrySet(props, "StartWorkingDirectory", options.Cwd);
+
+            if (options.Env is { Count: > 0 })
+            {
+                var serialized = string.Join("\n", System.Linq.Enumerable.Select(options.Env, kv => $"{kv.Key}={kv.Value}"));
+                TrySet(props, "EnvironmentVariables", serialized);
+            }
+        }
+        catch { }
+    }
+
+    private static void TrySet(EnvDTE.Properties props, string name, string? value)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (value is null) return;
+        try { props.Item(name).Value = value; } catch { }
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -66,6 +66,7 @@
     <Compile Include="RpcTarget.Project.cs" />
     <Compile Include="RpcTarget.Files.cs" />
     <Compile Include="RpcTarget.Build.cs" />
+    <Compile Include="RpcTarget.Debug.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Implements milestone **M4** — the core of VSMCP. 13 tools putting the VS debugger under AI control.
- Launch/attach/detach, the step family (into/over/out), break-all/continue, restart, run-to-cursor, guarded set-next-statement, and a rich \`debug.state\` snapshot.
- Built on \`EnvDTE.Debugger\` / \`Debugger2\` for reliability. Set-next-statement is gated by \`allowSideEffects=true\` and requires Break mode.

## Tool surface
| Tool | Purpose |
|---|---|
| \`debug.launch\` | Start debugging (optionally choose project, pass args/env/cwd, or \`noDebug\`) |
| \`debug.attach\` | Attach to running pid or process name, optional engine list |
| \`debug.stop\` / \`debug.detach\` / \`debug.restart\` | Session lifecycle |
| \`debug.break_all\` / \`debug.continue\` | Mode transitions |
| \`debug.step_into\` / \`step_over\` / \`step_out\` | Stepping |
| \`debug.run_to_cursor\` | Resume until a specific file:line |
| \`debug.set_next_statement\` | **Guarded** IP move; requires Break mode + \`allowSideEffects=true\` |
| \`debug.state\` | Mode, stopped reason, current process/thread/frame, last exception |

## Deferred
Streaming events (\`debug.started\`/\`stopped\`/\`breakpoint_hit\`/\`exception\`) — follow-up issue; callers poll \`debug.state\` for now.

## Test plan
- [ ] \`debug.launch\` on a solution with a configured startup runs the project under the debugger.
- [ ] \`debug.attach\` by pid attaches to a running HelloCrash fixture; \`debug.state\` shows Mode=Run.
- [ ] Trigger an unhandled NRE → \`debug.state\` reports Mode=Break, StoppedReason=Exception, LastExceptionMessage populated.
- [ ] \`debug.step_over\` transitions the current line in the snapshot.
- [ ] \`debug.set_next_statement\` returns WrongState without \`allowSideEffects=true\`.
- [ ] \`debug.set_next_statement\` returns WrongState when not in Break mode.
- [ ] \`debug.stop\` returns Mode=Design after the debuggee exits.

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)