### PR TITLE
M5: Breakpoints (closes #5)

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -462,4 +462,74 @@ public sealed class VsmcpTools
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.DebugStateAsync(ct).ConfigureAwait(false);
     }
+
+    [McpServerTool(Name = "bp.set")]
+    [Description("Set a breakpoint. Supports line (file+line), function, address, and data breakpoints, with optional condition, hit count, and disabled-on-create.")]
+    public async Task<BreakpointInfo> BreakpointSet(
+        [Description("Breakpoint options. For a line breakpoint set Kind=Line, File, and Line. See BreakpointSetOptions for the full schema.")] BreakpointSetOptions options,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BreakpointSetAsync(options, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "bp.set_tracepoint")]
+    [Description("Set a tracepoint (logpoint): emits a message to the Output window when hit without breaking. Use {expr} inside the message to evaluate expressions.")]
+    public async Task<BreakpointInfo> BreakpointSetTracepoint(
+        [Description("Absolute file path.")] string file,
+        [Description("1-based line number.")] int line,
+        [Description("Message to log. Use {expression} tokens for runtime values.")] string message,
+        [Description("Optional condition expression (break/log only when true).")] string? condition = null,
+        CancellationToken ct = default)
+    {
+        var options = new BreakpointSetOptions
+        {
+            Kind = BreakpointKind.Line,
+            File = file,
+            Line = line,
+            TracepointMessage = message,
+            ConditionKind = string.IsNullOrWhiteSpace(condition) ? BreakpointConditionKind.None : BreakpointConditionKind.WhenTrue,
+            ConditionExpression = condition,
+        };
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BreakpointSetAsync(options, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "bp.list")]
+    [Description("List all breakpoints created through VSMCP in this session.")]
+    public async Task<BreakpointListResult> BreakpointList(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BreakpointListAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "bp.remove")]
+    [Description("Remove a breakpoint by its VSMCP-minted id.")]
+    public async Task BreakpointRemove(
+        [Description("Breakpoint id returned from bp.set / bp.list.")] string bpId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        await proxy.BreakpointRemoveAsync(bpId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "bp.enable")]
+    [Description("Enable a previously-disabled breakpoint.")]
+    public async Task<BreakpointInfo> BreakpointEnable(
+        [Description("Breakpoint id.")] string bpId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BreakpointEnableAsync(bpId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "bp.disable")]
+    [Description("Disable a breakpoint without removing it.")]
+    public async Task<BreakpointInfo> BreakpointDisable(
+        [Description("Breakpoint id.")] string bpId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.BreakpointDisableAsync(bpId, ct).ConfigureAwait(false);
+    }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -64,4 +64,11 @@ public interface IVsmcpRpc
     Task<DebugActionResult> DebugRunToCursorAsync(string file, int line, CancellationToken cancellationToken = default);
     Task<DebugActionResult> DebugSetNextStatementAsync(string file, int line, bool allowSideEffects, CancellationToken cancellationToken = default);
     Task<DebugInfo> DebugStateAsync(CancellationToken cancellationToken = default);
+
+    // -------- Breakpoints --------
+    Task<BreakpointInfo> BreakpointSetAsync(BreakpointSetOptions options, CancellationToken cancellationToken = default);
+    Task<BreakpointListResult> BreakpointListAsync(CancellationToken cancellationToken = default);
+    Task BreakpointRemoveAsync(string bpId, CancellationToken cancellationToken = default);
+    Task<BreakpointInfo> BreakpointEnableAsync(string bpId, CancellationToken cancellationToken = default);
+    Task<BreakpointInfo> BreakpointDisableAsync(string bpId, CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M5Dtos.cs
+++ b/src/VSMCP.Shared/M5Dtos.cs
@@ -1,0 +1,95 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public enum BreakpointKind
+{
+    /// <summary>File + line (with optional column). The default.</summary>
+    Line = 0,
+    /// <summary>Function name match (e.g. "MyClass.DoWork"). All overloads by default.</summary>
+    Function = 1,
+    /// <summary>Memory address (hex string like "0x7FF123AB" or "0x...").</summary>
+    Address = 2,
+    /// <summary>Data breakpoint: break when a memory address is written to.</summary>
+    Data = 3,
+}
+
+public enum BreakpointHitKind
+{
+    /// <summary>Break every time the breakpoint is hit (default).</summary>
+    Always = 0,
+    /// <summary>Break when the hit count equals <see cref="BreakpointSetOptions.HitCount"/>.</summary>
+    HitCountEqual = 1,
+    /// <summary>Break once the hit count is >= <see cref="BreakpointSetOptions.HitCount"/>.</summary>
+    HitCountGreaterOrEqual = 2,
+    /// <summary>Break every Nth hit where N is <see cref="BreakpointSetOptions.HitCount"/>.</summary>
+    HitCountMultiple = 3,
+}
+
+public enum BreakpointConditionKind
+{
+    None = 0,
+    /// <summary>Break when the expression evaluates to true.</summary>
+    WhenTrue = 1,
+    /// <summary>Break when the expression's value changes between hits.</summary>
+    WhenChanged = 2,
+}
+
+public sealed class BreakpointSetOptions
+{
+    public BreakpointKind Kind { get; set; } = BreakpointKind.Line;
+
+    // Line breakpoints
+    public string? File { get; set; }
+    public int? Line { get; set; }
+    public int? Column { get; set; }
+
+    // Function breakpoints
+    public string? Function { get; set; }
+
+    // Address / data breakpoints
+    public string? Address { get; set; }
+    /// <summary>Bytes to watch for a data breakpoint (1, 2, 4, or 8).</summary>
+    public int? DataByteCount { get; set; }
+
+    // Common modifiers
+    public BreakpointConditionKind ConditionKind { get; set; } = BreakpointConditionKind.None;
+    public string? ConditionExpression { get; set; }
+
+    public BreakpointHitKind HitKind { get; set; } = BreakpointHitKind.Always;
+    public int? HitCount { get; set; }
+
+    /// <summary>When set, creates a tracepoint (logpoint) instead of a break: emits this message to the Output window without stopping.</summary>
+    public string? TracepointMessage { get; set; }
+
+    /// <summary>Start disabled (default: enabled).</summary>
+    public bool Disabled { get; set; }
+}
+
+public sealed class BreakpointInfo
+{
+    /// <summary>Opaque id minted by the VSIX. Stable for the lifetime of the session.</summary>
+    public string Id { get; set; } = "";
+    public BreakpointKind Kind { get; set; }
+    public string? File { get; set; }
+    public int? Line { get; set; }
+    public int? Column { get; set; }
+    public string? Function { get; set; }
+    public string? Address { get; set; }
+    public int? DataByteCount { get; set; }
+    public BreakpointConditionKind ConditionKind { get; set; }
+    public string? ConditionExpression { get; set; }
+    public BreakpointHitKind HitKind { get; set; }
+    public int? HitCount { get; set; }
+    public int CurrentHits { get; set; }
+    public bool Enabled { get; set; }
+    public bool IsTracepoint { get; set; }
+    public string? TracepointMessage { get; set; }
+    /// <summary>Number of concrete bind sites (a single file:line may resolve to multiple physical breakpoints).</summary>
+    public int BindSites { get; set; }
+}
+
+public sealed class BreakpointListResult
+{
+    public List<BreakpointInfo> Breakpoints { get; set; } = new();
+}

--- a/src/VSMCP.Vsix/RpcTarget.Breakpoints.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Breakpoints.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    // Id -> list of underlying EnvDTE breakpoints (one logical bp may bind in multiple places).
+    private static readonly ConcurrentDictionary<string, List<EnvDTE.Breakpoint>> s_bpStore = new();
+
+    public async Task<BreakpointInfo> BreakpointSetAsync(BreakpointSetOptions options, CancellationToken cancellationToken = default)
+    {
+        if (options is null) throw new VsmcpException(ErrorCodes.NotFound, "Options are required.");
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+
+        var bps = AddBreakpoints(dte, options);
+        if (bps.Count == 0)
+            throw new VsmcpException(ErrorCodes.InteropFault, "Visual Studio did not bind any breakpoint for the given options.");
+
+        var isTracepoint = !string.IsNullOrEmpty(options.TracepointMessage);
+        if (isTracepoint)
+            ApplyTracepoint(bps, options.TracepointMessage!);
+
+        if (options.Disabled)
+        {
+            foreach (var bp in bps) try { bp.Enabled = false; } catch { }
+        }
+
+        var id = Guid.NewGuid().ToString("N");
+        s_bpStore[id] = bps;
+
+        return BuildInfo(id, options.Kind, bps, isTracepoint, options.TracepointMessage);
+    }
+
+    public async Task<BreakpointListResult> BreakpointListAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        _ = await RequireDteAsync();
+
+        var result = new BreakpointListResult();
+        foreach (var kv in s_bpStore.ToArray())
+        {
+            var live = kv.Value.Where(IsLive).ToList();
+            if (live.Count == 0)
+            {
+                s_bpStore.TryRemove(kv.Key, out _);
+                continue;
+            }
+
+            var first = live[0];
+            var kind = InferKind(first);
+            var tp = ReadTracepoint(first);
+            result.Breakpoints.Add(BuildInfo(kv.Key, kind, live, tp.isTracepoint, tp.message));
+        }
+        return result;
+    }
+
+    public async Task BreakpointRemoveAsync(string bpId, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        _ = await RequireDteAsync();
+
+        if (!s_bpStore.TryRemove(bpId, out var bps))
+            throw new VsmcpException(ErrorCodes.NotFound, $"No breakpoint with id '{bpId}'.");
+
+        foreach (var bp in bps)
+        {
+            try { bp.Delete(); } catch { }
+        }
+    }
+
+    public async Task<BreakpointInfo> BreakpointEnableAsync(string bpId, CancellationToken cancellationToken = default)
+        => await SetEnabledAsync(bpId, true, cancellationToken);
+
+    public async Task<BreakpointInfo> BreakpointDisableAsync(string bpId, CancellationToken cancellationToken = default)
+        => await SetEnabledAsync(bpId, false, cancellationToken);
+
+    private async Task<BreakpointInfo> SetEnabledAsync(string bpId, bool enabled, CancellationToken cancellationToken)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        _ = await RequireDteAsync();
+
+        if (!s_bpStore.TryGetValue(bpId, out var bps))
+            throw new VsmcpException(ErrorCodes.NotFound, $"No breakpoint with id '{bpId}'.");
+
+        var live = bps.Where(IsLive).ToList();
+        if (live.Count == 0)
+        {
+            s_bpStore.TryRemove(bpId, out _);
+            throw new VsmcpException(ErrorCodes.NotFound, $"Breakpoint '{bpId}' no longer exists.");
+        }
+
+        foreach (var bp in live)
+        {
+            try { bp.Enabled = enabled; } catch { }
+        }
+
+        var tp = ReadTracepoint(live[0]);
+        return BuildInfo(bpId, InferKind(live[0]), live, tp.isTracepoint, tp.message);
+    }
+
+    // -------- helpers --------
+
+    private static List<EnvDTE.Breakpoint> AddBreakpoints(EnvDTE80.DTE2 dte, BreakpointSetOptions o)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+
+        var conditionType = o.ConditionKind switch
+        {
+            BreakpointConditionKind.WhenChanged => EnvDTE.dbgBreakpointConditionType.dbgBreakpointConditionTypeWhenChanged,
+            _ => EnvDTE.dbgBreakpointConditionType.dbgBreakpointConditionTypeWhenTrue,
+        };
+        var condition = o.ConditionKind == BreakpointConditionKind.None ? "" : (o.ConditionExpression ?? "");
+
+        var hitType = o.HitKind switch
+        {
+            BreakpointHitKind.HitCountEqual => EnvDTE.dbgHitCountType.dbgHitCountTypeEqual,
+            BreakpointHitKind.HitCountGreaterOrEqual => EnvDTE.dbgHitCountType.dbgHitCountTypeGreaterOrEqual,
+            BreakpointHitKind.HitCountMultiple => EnvDTE.dbgHitCountType.dbgHitCountTypeMultiple,
+            _ => EnvDTE.dbgHitCountType.dbgHitCountTypeNone,
+        };
+        var hitCount = o.HitKind == BreakpointHitKind.Always ? 0 : (o.HitCount ?? 1);
+
+        try
+        {
+            EnvDTE.Breakpoints added;
+            switch (o.Kind)
+            {
+                case BreakpointKind.Line:
+                    if (string.IsNullOrWhiteSpace(o.File) || o.Line is null or < 1)
+                        throw new VsmcpException(ErrorCodes.NotFound, "Line breakpoints require File and Line.");
+                    added = dte.Debugger.Breakpoints.Add(
+                        Function: "",
+                        File: o.File,
+                        Line: o.Line!.Value,
+                        Column: o.Column ?? 1,
+                        Condition: condition,
+                        ConditionType: conditionType,
+                        Language: "",
+                        Data: "",
+                        DataCount: 1,
+                        Address: "",
+                        HitCount: hitCount,
+                        HitCountType: hitType);
+                    break;
+
+                case BreakpointKind.Function:
+                    if (string.IsNullOrWhiteSpace(o.Function))
+                        throw new VsmcpException(ErrorCodes.NotFound, "Function breakpoints require Function.");
+                    added = dte.Debugger.Breakpoints.Add(
+                        Function: o.Function,
+                        File: "",
+                        Line: 1,
+                        Column: 1,
+                        Condition: condition,
+                        ConditionType: conditionType,
+                        Language: "",
+                        Data: "",
+                        DataCount: 1,
+                        Address: "",
+                        HitCount: hitCount,
+                        HitCountType: hitType);
+                    break;
+
+                case BreakpointKind.Address:
+                    if (string.IsNullOrWhiteSpace(o.Address))
+                        throw new VsmcpException(ErrorCodes.NotFound, "Address breakpoints require Address.");
+                    added = dte.Debugger.Breakpoints.Add(
+                        Function: "",
+                        File: "",
+                        Line: 1,
+                        Column: 1,
+                        Condition: condition,
+                        ConditionType: conditionType,
+                        Language: "",
+                        Data: "",
+                        DataCount: 1,
+                        Address: o.Address,
+                        HitCount: hitCount,
+                        HitCountType: hitType);
+                    break;
+
+                case BreakpointKind.Data:
+                    if (string.IsNullOrWhiteSpace(o.Address))
+                        throw new VsmcpException(ErrorCodes.NotFound, "Data breakpoints require Address (of the watched memory).");
+                    var count = o.DataByteCount ?? 4;
+                    if (count != 1 && count != 2 && count != 4 && count != 8)
+                        throw new VsmcpException(ErrorCodes.NotFound, "DataByteCount must be 1, 2, 4, or 8.");
+                    added = dte.Debugger.Breakpoints.Add(
+                        Function: "",
+                        File: "",
+                        Line: 1,
+                        Column: 1,
+                        Condition: condition,
+                        ConditionType: conditionType,
+                        Language: "",
+                        Data: o.Address,
+                        DataCount: count,
+                        Address: "",
+                        HitCount: hitCount,
+                        HitCountType: hitType);
+                    break;
+
+                default:
+                    throw new VsmcpException(ErrorCodes.Unsupported, $"Unsupported breakpoint kind: {o.Kind}.");
+            }
+
+            var list = new List<EnvDTE.Breakpoint>();
+            foreach (EnvDTE.Breakpoint bp in added) list.Add(bp);
+            return list;
+        }
+        catch (VsmcpException) { throw; }
+        catch (Exception ex)
+        {
+            throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to set breakpoint: {ex.Message}", ex);
+        }
+    }
+
+    private static void ApplyTracepoint(IEnumerable<EnvDTE.Breakpoint> bps, string message)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        foreach (var bp in bps)
+        {
+            if (bp is EnvDTE80.Breakpoint2 bp2)
+            {
+                try
+                {
+                    bp2.Message = message;
+                    bp2.BreakWhenHit = false;
+                }
+                catch { }
+            }
+        }
+    }
+
+    private static (bool isTracepoint, string? message) ReadTracepoint(EnvDTE.Breakpoint bp)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        if (bp is EnvDTE80.Breakpoint2 bp2)
+        {
+            try
+            {
+                var msg = bp2.Message;
+                if (!string.IsNullOrEmpty(msg)) return (!bp2.BreakWhenHit, msg);
+            }
+            catch { }
+        }
+        return (false, null);
+    }
+
+    private static bool IsLive(EnvDTE.Breakpoint bp)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try { _ = bp.Enabled; return true; }
+        catch { return false; }
+    }
+
+    private static BreakpointKind InferKind(EnvDTE.Breakpoint bp)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try
+        {
+            if (!string.IsNullOrEmpty(bp.FunctionName) && string.IsNullOrEmpty(bp.File)) return BreakpointKind.Function;
+        }
+        catch { }
+        return BreakpointKind.Line;
+    }
+
+    private static BreakpointInfo BuildInfo(string id, BreakpointKind kind, List<EnvDTE.Breakpoint> bps, bool isTracepoint, string? tpMessage)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var info = new BreakpointInfo
+        {
+            Id = id,
+            Kind = kind,
+            BindSites = bps.Count,
+            IsTracepoint = isTracepoint,
+            TracepointMessage = tpMessage,
+        };
+
+        var first = bps[0];
+        try { info.Enabled = first.Enabled; } catch { }
+        try { info.File = string.IsNullOrEmpty(first.File) ? null : first.File; } catch { }
+        try { info.Line = first.FileLine > 0 ? first.FileLine : (int?)null; } catch { }
+        try { info.Column = first.FileColumn > 0 ? first.FileColumn : (int?)null; } catch { }
+        try { info.Function = string.IsNullOrEmpty(first.FunctionName) ? null : first.FunctionName; } catch { }
+        try { info.ConditionExpression = string.IsNullOrEmpty(first.Condition) ? null : first.Condition; } catch { }
+
+        try
+        {
+            info.ConditionKind = first.ConditionType switch
+            {
+                EnvDTE.dbgBreakpointConditionType.dbgBreakpointConditionTypeWhenChanged => BreakpointConditionKind.WhenChanged,
+                EnvDTE.dbgBreakpointConditionType.dbgBreakpointConditionTypeWhenTrue when !string.IsNullOrEmpty(first.Condition) => BreakpointConditionKind.WhenTrue,
+                _ => BreakpointConditionKind.None,
+            };
+        }
+        catch { }
+
+        try
+        {
+            info.HitKind = first.HitCountType switch
+            {
+                EnvDTE.dbgHitCountType.dbgHitCountTypeEqual => BreakpointHitKind.HitCountEqual,
+                EnvDTE.dbgHitCountType.dbgHitCountTypeGreaterOrEqual => BreakpointHitKind.HitCountGreaterOrEqual,
+                EnvDTE.dbgHitCountType.dbgHitCountTypeMultiple => BreakpointHitKind.HitCountMultiple,
+                _ => BreakpointHitKind.Always,
+            };
+            info.HitCount = first.HitCountTarget > 0 ? first.HitCountTarget : (int?)null;
+            info.CurrentHits = first.CurrentHits;
+        }
+        catch { }
+
+        return info;
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -67,6 +67,7 @@
     <Compile Include="RpcTarget.Files.cs" />
     <Compile Include="RpcTarget.Build.cs" />
     <Compile Include="RpcTarget.Debug.cs" />
+    <Compile Include="RpcTarget.Breakpoints.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- Adds `bp.set`, `bp.set_tracepoint`, `bp.list`, `bp.remove`, `bp.enable`, `bp.disable` MCP tools.
- Supports line / function / address / data breakpoints with conditional (when-true / when-changed), hit-count (==, >=, multiple), tracepoint message, and disabled-on-create.
- VSIX mints opaque GUID ids that map to one or more underlying `EnvDTE.Breakpoint` instances (a single logical bp may bind in multiple physical sites).

## Test plan
- [ ] Launch Experimental VS, open a project, start Claude Code, connect to MCP, call `bp.set` for a file+line; verify a glyph appears in the gutter.
- [ ] Call `bp.list` and confirm the new bp id is returned.
- [ ] Call `bp.disable` / `bp.enable`; confirm glyph dim/solid state.
- [ ] Call `bp.set_tracepoint` with a `{expr}` message and run; confirm output appears in the Output window without stopping.
- [ ] Call `bp.remove`; confirm glyph disappears.

Closes #5.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>