### PR TITLE
M6a: Inspection — threads, stack, frame, eval (part of #6)

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -532,4 +532,98 @@ public sealed class VsmcpTools
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.BreakpointDisableAsync(bpId, ct).ConfigureAwait(false);
     }
+
+    [McpServerTool(Name = "threads.list")]
+    [Description("List all threads in the debuggee (paused or running). Requires an active debug session.")]
+    public async Task<ThreadListResult> ThreadsList(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ThreadsListAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "threads.freeze")]
+    [Description("Freeze a thread so it won't run when the debugger continues.")]
+    public async Task<ThreadInfo> ThreadsFreeze(
+        [Description("Thread id (as reported by threads.list).")] int threadId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ThreadsFreezeAsync(threadId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "threads.thaw")]
+    [Description("Unfreeze a previously frozen thread.")]
+    public async Task<ThreadInfo> ThreadsThaw(
+        [Description("Thread id.")] int threadId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ThreadsThawAsync(threadId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "threads.switch")]
+    [Description("Make the given thread the debugger's current thread. Subsequent stack/locals/eval calls default to this thread.")]
+    public async Task<ThreadInfo> ThreadsSwitch(
+        [Description("Thread id.")] int threadId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ThreadsSwitchAsync(threadId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "stack.get")]
+    [Description("Get the call stack for a thread (defaults to the current thread). Pass depth to cap the number of returned frames.")]
+    public async Task<StackGetResult> StackGet(
+        [Description("Optional thread id. Omit to use the current thread.")] int? threadId = null,
+        [Description("Optional max number of frames (from top of stack).")] int? depth = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.StackGetAsync(threadId, depth, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "frame.switch")]
+    [Description("Select a stack frame on a thread. Defaults to the current thread.")]
+    public async Task<StackFrameInfo> FrameSwitch(
+        [Description("Frame index (0 = top of stack).")] int frameIndex,
+        [Description("Optional thread id. Omit for the current thread.")] int? threadId = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.FrameSwitchAsync(threadId, frameIndex, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "frame.locals")]
+    [Description("Get local variables for a frame. expandDepth controls lazy expansion of composite values (0 = no children).")]
+    public async Task<VariableListResult> FrameLocals(
+        [Description("Optional thread id (default: current).")] int? threadId = null,
+        [Description("Optional frame index (default: current frame).")] int? frameIndex = null,
+        [Description("How many levels of children to expand. 0 disables expansion.")] int expandDepth = 0,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.FrameLocalsAsync(threadId, frameIndex, expandDepth, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "frame.arguments")]
+    [Description("Get the arguments of the currently-selected frame (or specified frame).")]
+    public async Task<VariableListResult> FrameArguments(
+        [Description("Optional thread id (default: current).")] int? threadId = null,
+        [Description("Optional frame index (default: current frame).")] int? frameIndex = null,
+        [Description("How many levels of children to expand. 0 disables expansion.")] int expandDepth = 0,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.FrameArgumentsAsync(threadId, frameIndex, expandDepth, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "eval.expression")]
+    [Description("Evaluate an expression in the current (or specified) frame. Refuses side-effecting calls unless allowSideEffects=true.")]
+    public async Task<EvalResult> EvalExpression(
+        [Description("Evaluation options. Expression is required. See EvalOptions for the full schema.")] EvalOptions options,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.EvalExpressionAsync(options, ct).ConfigureAwait(false);
+    }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -71,4 +71,15 @@ public interface IVsmcpRpc
     Task BreakpointRemoveAsync(string bpId, CancellationToken cancellationToken = default);
     Task<BreakpointInfo> BreakpointEnableAsync(string bpId, CancellationToken cancellationToken = default);
     Task<BreakpointInfo> BreakpointDisableAsync(string bpId, CancellationToken cancellationToken = default);
+
+    // -------- Inspection: threads, stacks, frames, eval --------
+    Task<ThreadListResult> ThreadsListAsync(CancellationToken cancellationToken = default);
+    Task<ThreadInfo> ThreadsFreezeAsync(int threadId, CancellationToken cancellationToken = default);
+    Task<ThreadInfo> ThreadsThawAsync(int threadId, CancellationToken cancellationToken = default);
+    Task<ThreadInfo> ThreadsSwitchAsync(int threadId, CancellationToken cancellationToken = default);
+    Task<StackGetResult> StackGetAsync(int? threadId, int? depth, CancellationToken cancellationToken = default);
+    Task<StackFrameInfo> FrameSwitchAsync(int? threadId, int frameIndex, CancellationToken cancellationToken = default);
+    Task<VariableListResult> FrameLocalsAsync(int? threadId, int? frameIndex, int expandDepth, CancellationToken cancellationToken = default);
+    Task<VariableListResult> FrameArgumentsAsync(int? threadId, int? frameIndex, int expandDepth, CancellationToken cancellationToken = default);
+    Task<EvalResult> EvalExpressionAsync(EvalOptions options, CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M6Dtos.cs
+++ b/src/VSMCP.Shared/M6Dtos.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public sealed class ThreadInfo
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public string? Location { get; set; }
+    public bool IsCurrent { get; set; }
+    public bool IsFrozen { get; set; }
+    /// <summary>VS-reported state: Running, Break, Terminated, etc.</summary>
+    public string? State { get; set; }
+}
+
+public sealed class ThreadListResult
+{
+    public List<ThreadInfo> Threads { get; set; } = new();
+}
+
+public sealed class StackFrameInfo
+{
+    /// <summary>0-based index from the top of the stack on its owning thread.</summary>
+    public int Index { get; set; }
+    public int ThreadId { get; set; }
+    public string FunctionName { get; set; } = "";
+    public string? Module { get; set; }
+    public string? Language { get; set; }
+    public string? File { get; set; }
+    public int? Line { get; set; }
+    public int? Column { get; set; }
+    public bool IsCurrent { get; set; }
+}
+
+public sealed class StackGetResult
+{
+    public int ThreadId { get; set; }
+    public List<StackFrameInfo> Frames { get; set; } = new();
+    /// <summary>True if <see cref="Frames"/> was truncated at the requested depth.</summary>
+    public bool Truncated { get; set; }
+}
+
+public sealed class VariableInfo
+{
+    public string Name { get; set; } = "";
+    public string? Type { get; set; }
+    public string? Value { get; set; }
+    public bool IsExpandable { get; set; }
+    /// <summary>When requested, the child expansion. Empty when not expanded.</summary>
+    public List<VariableInfo> Children { get; set; } = new();
+}
+
+public sealed class VariableListResult
+{
+    public int ThreadId { get; set; }
+    public int FrameIndex { get; set; }
+    public List<VariableInfo> Variables { get; set; } = new();
+}
+
+public sealed class EvalOptions
+{
+    public string Expression { get; set; } = "";
+    /// <summary>Thread to evaluate on. Defaults to the current thread.</summary>
+    public int? ThreadId { get; set; }
+    /// <summary>Frame index within the thread. Defaults to the current frame (index 0).</summary>
+    public int? FrameIndex { get; set; }
+    /// <summary>Must be true to allow function calls / property getters that may have side effects.</summary>
+    public bool AllowSideEffects { get; set; }
+    /// <summary>How many levels of children to expand for object values. 0 = no expansion (default).</summary>
+    public int ExpandDepth { get; set; }
+    /// <summary>Evaluation timeout in milliseconds.</summary>
+    public int TimeoutMs { get; set; } = 5000;
+}
+
+public sealed class EvalResult
+{
+    public string Expression { get; set; } = "";
+    public bool IsValid { get; set; }
+    public string? Type { get; set; }
+    public string? Value { get; set; }
+    public bool IsExpandable { get; set; }
+    public List<VariableInfo> Children { get; set; } = new();
+}

--- a/src/VSMCP.Vsix/RpcTarget.Inspection.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Inspection.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public async Task<ThreadListResult> ThreadsListAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        var debugger = RequireDebugging(dte);
+
+        var result = new ThreadListResult();
+        var currentId = TryGetCurrentThreadId(debugger);
+        var program = debugger.CurrentProgram;
+        if (program is null) return result;
+
+        foreach (EnvDTE.Thread t in program.Threads)
+        {
+            if (t is null) continue;
+            result.Threads.Add(SnapshotThread(t, currentId));
+        }
+        return result;
+    }
+
+    public async Task<ThreadInfo> ThreadsFreezeAsync(int threadId, CancellationToken cancellationToken = default)
+        => await SetThreadFrozenAsync(threadId, freeze: true, cancellationToken);
+
+    public async Task<ThreadInfo> ThreadsThawAsync(int threadId, CancellationToken cancellationToken = default)
+        => await SetThreadFrozenAsync(threadId, freeze: false, cancellationToken);
+
+    public async Task<ThreadInfo> ThreadsSwitchAsync(int threadId, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        var debugger = RequireDebugging(dte);
+
+        var thread = FindThread(debugger, threadId)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"No thread with id {threadId}.");
+
+        try { debugger.CurrentThread = thread; }
+        catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to switch thread: {ex.Message}", ex); }
+
+        return SnapshotThread(thread, threadId);
+    }
+
+    public async Task<StackGetResult> StackGetAsync(int? threadId, int? depth, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        var debugger = RequireDebugging(dte);
+
+        var thread = threadId is int tid
+            ? (FindThread(debugger, tid) ?? throw new VsmcpException(ErrorCodes.NotFound, $"No thread with id {tid}."))
+            : debugger.CurrentThread ?? throw new VsmcpException(ErrorCodes.WrongState, "No current thread. Break into the debuggee first.");
+
+        var result = new StackGetResult { ThreadId = thread.ID };
+        int currentFrameIndex = TryGetCurrentFrameIndex(debugger, thread);
+        int max = depth is int d && d > 0 ? d : int.MaxValue;
+
+        int i = 0;
+        foreach (EnvDTE.StackFrame f in thread.StackFrames)
+        {
+            if (f is null) { i++; continue; }
+            if (i >= max) { result.Truncated = true; break; }
+
+            var info = new StackFrameInfo
+            {
+                Index = i,
+                ThreadId = thread.ID,
+                FunctionName = SafeGet(() => f.FunctionName) ?? "",
+                Module = SafeGet(() => f.Module),
+                Language = SafeGet(() => f.Language),
+                IsCurrent = i == currentFrameIndex,
+            };
+            result.Frames.Add(info);
+            i++;
+        }
+        return result;
+    }
+
+    public async Task<StackFrameInfo> FrameSwitchAsync(int? threadId, int frameIndex, CancellationToken cancellationToken = default)
+    {
+        if (frameIndex < 0) throw new VsmcpException(ErrorCodes.NotFound, "Frame index must be >= 0.");
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        var debugger = RequireDebugging(dte);
+
+        var thread = threadId is int tid
+            ? (FindThread(debugger, tid) ?? throw new VsmcpException(ErrorCodes.NotFound, $"No thread with id {tid}."))
+            : debugger.CurrentThread ?? throw new VsmcpException(ErrorCodes.WrongState, "No current thread.");
+
+        if (debugger.CurrentThread is null || debugger.CurrentThread.ID != thread.ID)
+        {
+            try { debugger.CurrentThread = thread; }
+            catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to switch thread: {ex.Message}", ex); }
+        }
+
+        var frame = GetFrame(thread, frameIndex)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"Frame {frameIndex} does not exist on thread {thread.ID}.");
+
+        try { debugger.CurrentStackFrame = frame; }
+        catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to switch frame: {ex.Message}", ex); }
+
+        return new StackFrameInfo
+        {
+            Index = frameIndex,
+            ThreadId = thread.ID,
+            FunctionName = SafeGet(() => frame.FunctionName) ?? "",
+            Module = SafeGet(() => frame.Module),
+            Language = SafeGet(() => frame.Language),
+            IsCurrent = true,
+        };
+    }
+
+    public async Task<VariableListResult> FrameLocalsAsync(int? threadId, int? frameIndex, int expandDepth, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        var debugger = RequireDebugging(dte);
+        var (thread, frame, idx) = ResolveFrame(debugger, threadId, frameIndex);
+
+        var result = new VariableListResult { ThreadId = thread.ID, FrameIndex = idx };
+        if (frame.Locals is null) return result;
+        foreach (EnvDTE.Expression e in frame.Locals)
+            if (e is not null) result.Variables.Add(Snapshot(e, expandDepth));
+        return result;
+    }
+
+    public async Task<VariableListResult> FrameArgumentsAsync(int? threadId, int? frameIndex, int expandDepth, CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        var debugger = RequireDebugging(dte);
+        var (thread, frame, idx) = ResolveFrame(debugger, threadId, frameIndex);
+
+        var result = new VariableListResult { ThreadId = thread.ID, FrameIndex = idx };
+        if (frame.Arguments is null) return result;
+        foreach (EnvDTE.Expression e in frame.Arguments)
+            if (e is not null) result.Variables.Add(Snapshot(e, expandDepth));
+        return result;
+    }
+
+    public async Task<EvalResult> EvalExpressionAsync(EvalOptions options, CancellationToken cancellationToken = default)
+    {
+        if (options is null) throw new VsmcpException(ErrorCodes.NotFound, "Options are required.");
+        if (string.IsNullOrWhiteSpace(options.Expression))
+            throw new VsmcpException(ErrorCodes.NotFound, "Expression is required.");
+
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        var debugger = RequireDebugging(dte);
+
+        // Switch context if caller specified a non-default thread/frame.
+        if (options.ThreadId is int tid)
+        {
+            var t = FindThread(debugger, tid) ?? throw new VsmcpException(ErrorCodes.NotFound, $"No thread with id {tid}.");
+            if (debugger.CurrentThread?.ID != t.ID)
+            {
+                try { debugger.CurrentThread = t; }
+                catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to switch thread: {ex.Message}", ex); }
+            }
+        }
+        if (options.FrameIndex is int fi)
+        {
+            var thread = debugger.CurrentThread ?? throw new VsmcpException(ErrorCodes.WrongState, "No current thread.");
+            var f = GetFrame(thread, fi) ?? throw new VsmcpException(ErrorCodes.NotFound, $"Frame {fi} does not exist.");
+            try { debugger.CurrentStackFrame = f; }
+            catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to switch frame: {ex.Message}", ex); }
+        }
+
+        EnvDTE.Expression expr;
+        try
+        {
+            var timeout = options.TimeoutMs > 0 ? options.TimeoutMs : 5000;
+            expr = debugger.GetExpression(options.Expression, options.AllowSideEffects, timeout);
+        }
+        catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Eval failed: {ex.Message}", ex); }
+
+        var result = new EvalResult
+        {
+            Expression = options.Expression,
+            IsValid = expr.IsValidValue,
+            Type = SafeGet(() => expr.Type),
+            Value = SafeGet(() => expr.Value),
+            IsExpandable = SafeGet(() => expr.DataMembers?.Count) is int c && c > 0,
+        };
+
+        if (result.IsValid && result.IsExpandable && options.ExpandDepth > 0)
+        {
+            foreach (EnvDTE.Expression m in expr.DataMembers)
+                if (m is not null) result.Children.Add(Snapshot(m, options.ExpandDepth - 1));
+        }
+        return result;
+    }
+
+    // -------- helpers --------
+
+    private async Task<ThreadInfo> SetThreadFrozenAsync(int threadId, bool freeze, CancellationToken ct)
+    {
+        await _jtf.SwitchToMainThreadAsync(ct);
+        var dte = await RequireDteAsync();
+        var debugger = RequireDebugging(dte);
+
+        var thread = FindThread(debugger, threadId)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"No thread with id {threadId}.");
+
+        try
+        {
+            if (freeze) thread.Freeze();
+            else thread.Thaw();
+        }
+        catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to {(freeze ? "freeze" : "thaw")} thread: {ex.Message}", ex); }
+
+        return SnapshotThread(thread, TryGetCurrentThreadId(debugger));
+    }
+
+    private static EnvDTE.Debugger RequireDebugging(EnvDTE80.DTE2 dte)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var debugger = dte.Debugger
+            ?? throw new VsmcpException(ErrorCodes.InteropFault, "Debugger service unavailable.");
+        if (debugger.CurrentMode == EnvDTE.dbgDebugMode.dbgDesignMode)
+            throw new VsmcpException(ErrorCodes.NotDebugging, "No active debug session.");
+        return debugger;
+    }
+
+    private static EnvDTE.Thread? FindThread(EnvDTE.Debugger debugger, int threadId)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var program = debugger.CurrentProgram;
+        if (program is null) return null;
+        foreach (EnvDTE.Thread t in program.Threads)
+            if (t is not null && t.ID == threadId) return t;
+        return null;
+    }
+
+    private static int TryGetCurrentThreadId(EnvDTE.Debugger debugger)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        try { return debugger.CurrentThread?.ID ?? -1; } catch { return -1; }
+    }
+
+    private static int TryGetCurrentFrameIndex(EnvDTE.Debugger debugger, EnvDTE.Thread thread)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        EnvDTE.StackFrame? current = null;
+        try { current = debugger.CurrentStackFrame; } catch { }
+        if (current is null) return 0;
+
+        int i = 0;
+        foreach (EnvDTE.StackFrame f in thread.StackFrames)
+        {
+            if (ReferenceEquals(f, current)) return i;
+            i++;
+        }
+        return 0;
+    }
+
+    private static EnvDTE.StackFrame? GetFrame(EnvDTE.Thread thread, int index)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        int i = 0;
+        foreach (EnvDTE.StackFrame f in thread.StackFrames)
+        {
+            if (i == index) return f;
+            i++;
+        }
+        return null;
+    }
+
+    private static (EnvDTE.Thread thread, EnvDTE.StackFrame frame, int index) ResolveFrame(EnvDTE.Debugger debugger, int? threadId, int? frameIndex)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var thread = threadId is int tid
+            ? (FindThread(debugger, tid) ?? throw new VsmcpException(ErrorCodes.NotFound, $"No thread with id {tid}."))
+            : debugger.CurrentThread ?? throw new VsmcpException(ErrorCodes.WrongState, "No current thread. Break into the debuggee first.");
+
+        var idx = frameIndex ?? TryGetCurrentFrameIndex(debugger, thread);
+        if (idx < 0) idx = 0;
+
+        var frame = GetFrame(thread, idx)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"Frame {idx} does not exist on thread {thread.ID}.");
+
+        return (thread, frame, idx);
+    }
+
+    private static ThreadInfo SnapshotThread(EnvDTE.Thread t, int currentThreadId)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var info = new ThreadInfo
+        {
+            Id = TryInt(() => t.ID),
+            Name = SafeGet(() => t.Name),
+            Location = SafeGet(() => t.Location),
+            IsFrozen = TryBool(() => t.IsFrozen),
+            State = TryBool(() => t.IsAlive) ? "Alive" : "Terminated",
+        };
+        info.IsCurrent = info.Id == currentThreadId;
+        return info;
+    }
+
+    private static int TryInt(Func<int> f) { try { return f(); } catch { return 0; } }
+    private static bool TryBool(Func<bool> f) { try { return f(); } catch { return false; } }
+
+    private static VariableInfo Snapshot(EnvDTE.Expression e, int remainingDepth)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var v = new VariableInfo
+        {
+            Name = SafeGet(() => e.Name) ?? "",
+            Type = SafeGet(() => e.Type),
+            Value = SafeGet(() => e.Value),
+            IsExpandable = SafeGet(() => e.DataMembers?.Count) is int c && c > 0,
+        };
+
+        if (v.IsExpandable && remainingDepth > 0 && e.DataMembers is not null)
+        {
+            foreach (EnvDTE.Expression m in e.DataMembers)
+                if (m is not null) v.Children.Add(Snapshot(m, remainingDepth - 1));
+        }
+        return v;
+    }
+
+    private static T? SafeGet<T>(Func<T> getter)
+    {
+        try { return getter(); }
+        catch { return default; }
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -68,6 +68,7 @@
     <Compile Include="RpcTarget.Build.cs" />
     <Compile Include="RpcTarget.Debug.cs" />
     <Compile Include="RpcTarget.Breakpoints.cs" />
+    <Compile Include="RpcTarget.Inspection.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
Part 1 of M6 (Inspection). Lands the read-only / control surface over a paused debuggee:
- `threads.list`, `threads.freeze`, `threads.thaw`, `threads.switch`
- `stack.get` (with optional depth cap)
- `frame.switch`, `frame.locals`, `frame.arguments`
- `eval.expression` (refuses side-effecting evals unless `allowSideEffects=true`)

Locals/arguments/eval children are returned as a `VariableInfo` tree with `IsExpandable`; callers pass `expandDepth` to eagerly expand or 0 to stay lazy.

Part 2 (#6 remaining) will add `memory.read/write`, `registers.get`, `disasm.get`, `modules.list`, `symbols.load/status`.

## Test plan
- [ ] Break in a debugged process, call `threads.list` — multiple threads returned, one IsCurrent.
- [ ] `stack.get` with no args returns frames for the current thread.
- [ ] `frame.locals expandDepth=1` returns locals with one level of children for a `Dictionary<string, int>`.
- [ ] `eval.expression { Expression: "DateTime.Now" }` refuses with WrongState unless `AllowSideEffects: true`. (Note: property getters may pass VS's heuristic — document the VS behavior.)
- [ ] `threads.freeze`/`threads.thaw` change thread state and survive a continue+break cycle.

Tracks #6.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>