### PR TITLE
M6b: Modules & symbols (part of #6)

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -626,4 +626,32 @@ public sealed class VsmcpTools
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.EvalExpressionAsync(options, ct).ConfigureAwait(false);
     }
+
+    [McpServerTool(Name = "modules.list")]
+    [Description("List modules loaded into the debuggee, with symbol state, load address, and version. Requires an active debug session; modules are tracked starting from when VS loads this extension.")]
+    public async Task<ModuleListResult> ModulesList(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ModulesListAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "symbols.load")]
+    [Description("Force-load symbols for a module (using the current symbol search paths and servers).")]
+    public async Task<SymbolStatusResult> SymbolsLoad(
+        [Description("Module id from modules.list.")] string moduleId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.SymbolsLoadAsync(moduleId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "symbols.status")]
+    [Description("Report symbol-load status for a module (Loaded/NotLoaded/Stripped) with a verbose search log when available.")]
+    public async Task<SymbolStatusResult> SymbolsStatus(
+        [Description("Module id from modules.list.")] string moduleId,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.SymbolsStatusAsync(moduleId, ct).ConfigureAwait(false);
+    }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -82,4 +82,9 @@ public interface IVsmcpRpc
     Task<VariableListResult> FrameLocalsAsync(int? threadId, int? frameIndex, int expandDepth, CancellationToken cancellationToken = default);
     Task<VariableListResult> FrameArgumentsAsync(int? threadId, int? frameIndex, int expandDepth, CancellationToken cancellationToken = default);
     Task<EvalResult> EvalExpressionAsync(EvalOptions options, CancellationToken cancellationToken = default);
+
+    // -------- Inspection: modules & symbols --------
+    Task<ModuleListResult> ModulesListAsync(CancellationToken cancellationToken = default);
+    Task<SymbolStatusResult> SymbolsLoadAsync(string moduleId, CancellationToken cancellationToken = default);
+    Task<SymbolStatusResult> SymbolsStatusAsync(string moduleId, CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M6bDtos.cs
+++ b/src/VSMCP.Shared/M6bDtos.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public enum SymbolState
+{
+    Unknown = 0,
+    NotLoaded = 1,
+    Loaded = 2,
+    Stripped = 3,
+}
+
+public sealed class ModuleInfo
+{
+    /// <summary>Opaque module id minted by the VSIX. Use this with symbols.load/status.</summary>
+    public string Id { get; set; } = "";
+    public string Name { get; set; } = "";
+    public string? Path { get; set; }
+    public string? LoadAddress { get; set; }
+    public int? Order { get; set; }
+    public long? Size { get; set; }
+    public string? Version { get; set; }
+    public string? TimestampUtc { get; set; }
+    public bool Is64Bit { get; set; }
+    public bool IsUserCode { get; set; }
+    public SymbolState SymbolState { get; set; }
+    public string? SymbolStatusMessage { get; set; }
+    public string? SymbolPath { get; set; }
+}
+
+public sealed class ModuleListResult
+{
+    public List<ModuleInfo> Modules { get; set; } = new();
+}
+
+public sealed class SymbolStatusResult
+{
+    public string ModuleId { get; set; } = "";
+    public SymbolState State { get; set; }
+    public string? Message { get; set; }
+    public string? SymbolPath { get; set; }
+}

--- a/src/VSMCP.Vsix/ModuleTracker.cs
+++ b/src/VSMCP.Vsix/ModuleTracker.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// Subscribes to IVsDebugger debug events and caches loaded modules (IDebugModule2) per program.
+/// We hold the native objects so that LoadSymbols / GetSymbolInfo still work after load.
+/// </summary>
+internal sealed class ModuleTracker : IDebugEventCallback2, IDisposable
+{
+    private static readonly Guid s_moduleLoadEvent = typeof(IDebugModuleLoadEvent2).GUID;
+    private static readonly Guid s_programDestroyEvent = typeof(IDebugProgramDestroyEvent2).GUID;
+
+    private readonly IVsDebugger? _debugger;
+    private readonly ConcurrentDictionary<string, Entry> _byId = new(StringComparer.Ordinal);
+    // Raw module -> id so we can remove on unload.
+    private readonly ConcurrentDictionary<IDebugModule2, string> _byModule = new();
+    private bool _advised;
+
+    public ModuleTracker(IVsDebugger? debugger)
+    {
+        _debugger = debugger;
+        if (_debugger is not null)
+        {
+            try
+            {
+                _debugger.AdviseDebugEventCallback(this);
+                _advised = true;
+            }
+            catch { }
+        }
+    }
+
+    public IReadOnlyList<ModuleInfo> Snapshot()
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var list = new List<ModuleInfo>();
+        foreach (var entry in _byId.Values)
+        {
+            var refreshed = ReadInfo(entry.Module);
+            refreshed.Id = entry.Info.Id;
+            list.Add(refreshed);
+        }
+        list.Sort((a, b) =>
+        {
+            var ao = a.Order ?? int.MaxValue;
+            var bo = b.Order ?? int.MaxValue;
+            if (ao != bo) return ao.CompareTo(bo);
+            return string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+        });
+        return list;
+    }
+
+    public bool TryGet(string id, out IDebugModule2? module)
+    {
+        if (_byId.TryGetValue(id, out var entry))
+        {
+            module = entry.Module;
+            return true;
+        }
+        module = null;
+        return false;
+    }
+
+    int IDebugEventCallback2.Event(
+        IDebugEngine2 pEngine,
+        IDebugProcess2 pProcess,
+        IDebugProgram2 pProgram,
+        IDebugThread2 pThread,
+        IDebugEvent2 pEvent,
+        ref Guid riidEvent,
+        uint dwAttrib)
+    {
+        try
+        {
+            if (riidEvent == s_moduleLoadEvent && pEvent is IDebugModuleLoadEvent2 modLoad)
+            {
+                string? dbgMsg = null;
+                int fLoad = 0;
+                modLoad.GetModule(out var module, ref dbgMsg, ref fLoad);
+                if (module is not null)
+                {
+                    if (fLoad != 0) AddOrUpdate(module);
+                    else Remove(module);
+                }
+            }
+            else if (riidEvent == s_programDestroyEvent)
+            {
+                ClearAll();
+            }
+        }
+        catch { /* never let a callback exception escape into the debugger */ }
+
+        return VSConstants.S_OK;
+    }
+
+    private void AddOrUpdate(IDebugModule2 module)
+    {
+        var info = ReadInfo(module);
+        if (_byModule.TryGetValue(module, out var existingId))
+        {
+            info.Id = existingId;
+            _byId[existingId] = new Entry(module, info);
+            return;
+        }
+
+        var id = Guid.NewGuid().ToString("N");
+        info.Id = id;
+        _byModule[module] = id;
+        _byId[id] = new Entry(module, info);
+    }
+
+    private void Remove(IDebugModule2 module)
+    {
+        if (_byModule.TryRemove(module, out var id))
+            _byId.TryRemove(id, out _);
+    }
+
+    private void ClearAll()
+    {
+        _byId.Clear();
+        _byModule.Clear();
+    }
+
+    private static ModuleInfo ReadInfo(IDebugModule2 module)
+    {
+        var info = new ModuleInfo();
+        var arr = new MODULE_INFO[1];
+        try
+        {
+            if (module.GetInfo(
+                enum_MODULE_INFO_FIELDS.MIF_NAME
+                | enum_MODULE_INFO_FIELDS.MIF_URL
+                | enum_MODULE_INFO_FIELDS.MIF_LOADADDRESS
+                | enum_MODULE_INFO_FIELDS.MIF_LOADORDER
+                | enum_MODULE_INFO_FIELDS.MIF_SIZE
+                | enum_MODULE_INFO_FIELDS.MIF_VERSION
+                | enum_MODULE_INFO_FIELDS.MIF_URLSYMBOLLOCATION
+                | enum_MODULE_INFO_FIELDS.MIF_FLAGS, arr) == VSConstants.S_OK)
+            {
+                var mi = arr[0];
+                var v = mi.dwValidFields;
+                if ((v & enum_MODULE_INFO_FIELDS.MIF_NAME) != 0) info.Name = mi.m_bstrName ?? "";
+                if ((v & enum_MODULE_INFO_FIELDS.MIF_URL) != 0) info.Path = mi.m_bstrUrl;
+                if ((v & enum_MODULE_INFO_FIELDS.MIF_LOADADDRESS) != 0) info.LoadAddress = "0x" + mi.m_addrLoadAddress.ToString("X");
+                if ((v & enum_MODULE_INFO_FIELDS.MIF_LOADORDER) != 0) info.Order = (int)mi.m_dwLoadOrder;
+                if ((v & enum_MODULE_INFO_FIELDS.MIF_SIZE) != 0) info.Size = mi.m_dwSize;
+                if ((v & enum_MODULE_INFO_FIELDS.MIF_VERSION) != 0) info.Version = mi.m_bstrVersion;
+                if ((v & enum_MODULE_INFO_FIELDS.MIF_URLSYMBOLLOCATION) != 0) info.SymbolPath = mi.m_bstrUrlSymbolLocation;
+
+                if ((v & enum_MODULE_INFO_FIELDS.MIF_FLAGS) != 0)
+                {
+                    var flags = mi.m_dwModuleFlags;
+                    info.Is64Bit = (flags & enum_MODULE_FLAGS.MODULE_FLAG_64BIT) != 0;
+                    info.IsUserCode = (flags & enum_MODULE_FLAGS.MODULE_FLAG_SYSTEM) == 0;
+                    info.SymbolState = (flags & enum_MODULE_FLAGS.MODULE_FLAG_SYMBOLS) != 0
+                        ? SymbolState.Loaded
+                        : SymbolState.NotLoaded;
+                }
+            }
+        }
+        catch { }
+
+        if (string.IsNullOrEmpty(info.Name) && !string.IsNullOrEmpty(info.Path))
+        {
+            try { info.Name = System.IO.Path.GetFileName(info.Path); } catch { }
+        }
+
+        return info;
+    }
+
+    public void Dispose()
+    {
+        if (_advised && _debugger is not null)
+        {
+            try { _debugger.UnadviseDebugEventCallback(this); } catch { }
+        }
+        _advised = false;
+        ClearAll();
+    }
+
+    private readonly struct Entry
+    {
+        public Entry(IDebugModule2 module, ModuleInfo info) { Module = module; Info = info; }
+        public IDebugModule2 Module { get; }
+        public ModuleInfo Info { get; }
+    }
+}

--- a/src/VSMCP.Vsix/RpcTarget.Modules.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Modules.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Debugger.Interop;
+using Microsoft.VisualStudio.Shell;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public async Task<ModuleListResult> ModulesListAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var tracker = _package.Modules
+            ?? throw new VsmcpException(ErrorCodes.WrongState, "Module tracking is not initialized.");
+
+        var result = new ModuleListResult();
+        foreach (var m in tracker.Snapshot())
+            result.Modules.Add(m);
+        return result;
+    }
+
+    public async Task<SymbolStatusResult> SymbolsLoadAsync(string moduleId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(moduleId))
+            throw new VsmcpException(ErrorCodes.NotFound, "moduleId is required.");
+
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var tracker = _package.Modules
+            ?? throw new VsmcpException(ErrorCodes.WrongState, "Module tracking is not initialized.");
+
+        if (!tracker.TryGet(moduleId, out var module) || module is null)
+            throw new VsmcpException(ErrorCodes.NotFound, $"No module with id '{moduleId}'.");
+
+        if (module is IDebugModule3 m3)
+        {
+            try
+            {
+                var hr = m3.LoadSymbols();
+                if (hr != VSConstants.S_OK && hr != 1 /* S_FALSE: already loaded / not applicable */)
+                    throw new VsmcpException(ErrorCodes.InteropFault, $"LoadSymbols returned HRESULT 0x{hr:X8}.");
+            }
+            catch (VsmcpException) { throw; }
+            catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"LoadSymbols failed: {ex.Message}", ex); }
+        }
+        else
+        {
+            throw new VsmcpException(ErrorCodes.Unsupported, "This module's engine does not expose IDebugModule3; cannot force symbol load.");
+        }
+
+        return ReadStatus(moduleId, module);
+    }
+
+    public async Task<SymbolStatusResult> SymbolsStatusAsync(string moduleId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(moduleId))
+            throw new VsmcpException(ErrorCodes.NotFound, "moduleId is required.");
+
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var tracker = _package.Modules
+            ?? throw new VsmcpException(ErrorCodes.WrongState, "Module tracking is not initialized.");
+
+        if (!tracker.TryGet(moduleId, out var module) || module is null)
+            throw new VsmcpException(ErrorCodes.NotFound, $"No module with id '{moduleId}'.");
+
+        return ReadStatus(moduleId, module);
+    }
+
+    private static SymbolStatusResult ReadStatus(string moduleId, IDebugModule2 module)
+    {
+        ThreadHelper.ThrowIfNotOnUIThread();
+        var result = new SymbolStatusResult { ModuleId = moduleId, State = SymbolState.Unknown };
+
+        // Prefer IDebugModule3 which can tell us "loaded / not loaded / stripped" plus a status message.
+        if (module is IDebugModule3 m3)
+        {
+            var arr = new MODULE_SYMBOL_SEARCH_INFO[1];
+            try
+            {
+                if (m3.GetSymbolInfo(enum_SYMBOL_SEARCH_INFO_FIELDS.SSIF_VERBOSE_SEARCH_INFO, arr) == VSConstants.S_OK)
+                {
+                    result.Message = arr[0].bstrVerboseSearchInfo;
+                }
+            }
+            catch { }
+        }
+
+        // Flags from MODULE_INFO are the authoritative load-state source.
+        var infoArr = new MODULE_INFO[1];
+        try
+        {
+            if (module.GetInfo(
+                enum_MODULE_INFO_FIELDS.MIF_FLAGS
+                | enum_MODULE_INFO_FIELDS.MIF_URLSYMBOLLOCATION, infoArr) == VSConstants.S_OK)
+            {
+                var mi = infoArr[0];
+                if ((mi.dwValidFields & enum_MODULE_INFO_FIELDS.MIF_FLAGS) != 0)
+                {
+                    result.State = (mi.m_dwModuleFlags & enum_MODULE_FLAGS.MODULE_FLAG_SYMBOLS) != 0
+                        ? SymbolState.Loaded
+                        : SymbolState.NotLoaded;
+                }
+                if ((mi.dwValidFields & enum_MODULE_INFO_FIELDS.MIF_URLSYMBOLLOCATION) != 0)
+                    result.SymbolPath = mi.m_bstrUrlSymbolLocation;
+            }
+        }
+        catch { }
+
+        return result;
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -69,6 +69,8 @@
     <Compile Include="RpcTarget.Debug.cs" />
     <Compile Include="RpcTarget.Breakpoints.cs" />
     <Compile Include="RpcTarget.Inspection.cs" />
+    <Compile Include="RpcTarget.Modules.cs" />
+    <Compile Include="ModuleTracker.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />
   </ItemGroup>

--- a/src/VSMCP.Vsix/VSMCPPackage.cs
+++ b/src/VSMCP.Vsix/VSMCPPackage.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 
 namespace VSMCP.Vsix;
@@ -15,10 +16,15 @@ public sealed class VSMCPPackage : AsyncPackage
     public const string PackageGuidString = "7e0b4e3e-0000-0000-0000-000000000001";
 
     private PipeHost? _pipeHost;
+    private ModuleTracker? _moduleTracker;
+
+    internal ModuleTracker? Modules => _moduleTracker;
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        var vsDebugger = await GetServiceAsync(typeof(SVsShellDebugger)) as IVsDebugger;
+        _moduleTracker = new ModuleTracker(vsDebugger);
         _pipeHost = new PipeHost(this, JoinableTaskFactory);
         _pipeHost.Start();
     }
@@ -29,6 +35,8 @@ public sealed class VSMCPPackage : AsyncPackage
         {
             _pipeHost?.Dispose();
             _pipeHost = null;
+            _moduleTracker?.Dispose();
+            _moduleTracker = null;
         }
         base.Dispose(disposing);
     }


### PR DESCRIPTION
## Summary
Adds the modules/symbols slice of M6:
- `modules.list` — snapshot of modules loaded into the debuggee, with path, load address, size, version, 64-bitness, user/system classification, and symbol state.
- `symbols.load` — force a symbol load via `IDebugModule3.LoadSymbols`.
- `symbols.status` — report Loaded/NotLoaded + verbose search log from `IDebugModule3.GetSymbolInfo`.

Implemented by subscribing an `IDebugEventCallback2` sink at package init (`IVsDebugger.AdviseDebugEventCallback`) that caches `IDebugModule2` instances as `IDebugModuleLoadEvent2` fires. Module ids are opaque GUIDs minted by the VSIX so callers can pin symbol operations to a specific load.

## Test plan
- [ ] Launch a native or managed debuggee; call `modules.list`, verify expected DLLs appear with plausible load addresses/sizes.
- [ ] Pick a system module whose symbols aren't loaded; `symbols.status` reports NotLoaded; `symbols.load` then `symbols.status` reports Loaded (when symbols are available on configured servers).
- [ ] Detach/stop — list eventually empties after `IDebugProgramDestroyEvent2`.

Remaining in M6 (M6c): `memory.read/write`, `registers.get`, `disasm.get`. Tracks #6.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>