### PR TITLE
M7: Crash-dump analysis (dump.open, dump.summary, dump.save)

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -699,4 +699,36 @@ public sealed class VsmcpTools
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.DisasmGetAsync(address, count, ct).ConfigureAwait(false);
     }
+
+    [McpServerTool(Name = "dump.open")]
+    [Description("Load a crash dump (.dmp / minidump / full dump) into Visual Studio and start a dump debug session. After this call, the standard threads.*/stack.*/frame.*/eval.*/modules.* tools operate on the dump.")]
+    public async Task<DumpOpenResult> DumpOpen(
+        [Description("Absolute path to the dump file.")] string path,
+        [Description("Optional extra symbol search paths (semicolon-separated). Reserved; VS's configured SymbolPath is used in v1.")] string? symbolPath = null,
+        [Description("Optional extra source search paths. Reserved in v1.")] string? sourcePath = null,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DumpOpenAsync(new DumpOpenOptions { Path = path, SymbolPath = symbolPath, SourcePath = sourcePath }, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "dump.summary")]
+    [Description("Summarize the current dump/debug session: faulting thread, exception text, process id, and the loaded-module count split by managed/native. Requires an active debug session (dump or live).")]
+    public async Task<DumpSummaryResult> DumpSummary(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DumpSummaryAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "dump.save")]
+    [Description("Capture a memory dump of a running process (not necessarily the debuggee) using dbghelp!MiniDumpWriteDump. Writes to the given path; parent directory must exist and Visual Studio must have rights to read the target process.")]
+    public async Task<DumpSaveResult> DumpSave(
+        [Description("Target process id.")] int pid,
+        [Description("Absolute destination path for the dump file.")] string path,
+        [Description("When true (default), write a full-memory dump. False writes a smaller minidump (stacks + modules + handles + thread info).")] bool full = true,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DumpSaveAsync(new DumpSaveOptions { Pid = pid, Path = path, Full = full }, ct).ConfigureAwait(false);
+    }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -93,4 +93,9 @@ public interface IVsmcpRpc
     Task<MemoryWriteResult> MemoryWriteAsync(string address, string hex, bool allowSideEffects, CancellationToken cancellationToken = default);
     Task<RegistersResult> RegistersGetAsync(int? threadId, int? frameIndex, CancellationToken cancellationToken = default);
     Task<DisasmResult> DisasmGetAsync(string address, int count, CancellationToken cancellationToken = default);
+
+    // -------- Crash-dump analysis --------
+    Task<DumpOpenResult> DumpOpenAsync(DumpOpenOptions options, CancellationToken cancellationToken = default);
+    Task<DumpSummaryResult> DumpSummaryAsync(CancellationToken cancellationToken = default);
+    Task<DumpSaveResult> DumpSaveAsync(DumpSaveOptions options, CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M7Dtos.cs
+++ b/src/VSMCP.Shared/M7Dtos.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public sealed class DumpOpenOptions
+{
+    /// <summary>Absolute path to a .dmp / .mdmp / minidump file.</summary>
+    public string Path { get; set; } = "";
+    /// <summary>Extra symbol search paths (semicolon-separated) to layer on top of VS's configured SymbolPath for this session. Reserved — not applied in v1.</summary>
+    public string? SymbolPath { get; set; }
+    /// <summary>Extra source search paths (semicolon-separated). Reserved — not applied in v1.</summary>
+    public string? SourcePath { get; set; }
+}
+
+public sealed class DumpOpenResult
+{
+    public string Path { get; set; } = "";
+    /// <summary>Reported at load time if the engine surfaced a faulting/current thread id.</summary>
+    public int? FaultingThreadId { get; set; }
+    /// <summary>Text of the exception that surfaced on dump load, when available.</summary>
+    public string? ExceptionMessage { get; set; }
+    /// <summary>Number of modules visible after the dump loaded (best-effort — modules that loaded before the extension bound the event sink won't appear).</summary>
+    public int ModuleCount { get; set; }
+}
+
+public sealed class DumpSummaryResult
+{
+    public int? FaultingThreadId { get; set; }
+    public string? FaultingThreadName { get; set; }
+    public string? ExceptionMessage { get; set; }
+    public DebugMode Mode { get; set; }
+    public int ModuleCount { get; set; }
+    public int ManagedModuleCount { get; set; }
+    public int NativeModuleCount { get; set; }
+    public List<ModuleInfo> Modules { get; set; } = new();
+    /// <summary>Process id reported by the debug engine, if any.</summary>
+    public int? ProcessId { get; set; }
+    public string? ProcessName { get; set; }
+}
+
+public sealed class DumpSaveOptions
+{
+    /// <summary>Target process id. Must be accessible to devenv.exe (same user, or devenv elevated).</summary>
+    public int Pid { get; set; }
+    /// <summary>Absolute destination path. Parent directory must exist.</summary>
+    public string Path { get; set; } = "";
+    /// <summary>When true, writes a full-memory dump (MiniDumpWithFullMemory + typical heap/handle/token flags). False = minidump (stacks + modules).</summary>
+    public bool Full { get; set; } = true;
+}
+
+public sealed class DumpSaveResult
+{
+    public string Path { get; set; } = "";
+    public long BytesWritten { get; set; }
+    public bool Full { get; set; }
+}

--- a/src/VSMCP.Vsix/RpcTarget.Dump.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Dump.cs
@@ -1,0 +1,227 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public async Task<DumpOpenResult> DumpOpenAsync(DumpOpenOptions options, CancellationToken cancellationToken = default)
+    {
+        if (options is null) throw new VsmcpException(ErrorCodes.NotFound, "Options are required.");
+        if (string.IsNullOrWhiteSpace(options.Path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Dump path is required.");
+        var path = Path.GetFullPath(options.Path);
+        if (!File.Exists(path))
+            throw new VsmcpException(ErrorCodes.NotFound, $"Dump file not found: {path}");
+
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+
+        // Opening a .dmp through ItemOperations routes it to the Dump Summary editor.
+        // Debug.Start then invokes the Mini-Dump Debug Engine on the opened document.
+        try
+        {
+            dte.ItemOperations.OpenFile(path, EnvDTE.Constants.vsViewKindPrimary);
+        }
+        catch (Exception ex)
+        {
+            throw new VsmcpException(ErrorCodes.InteropFault, $"Failed to open dump document: {ex.Message}", ex);
+        }
+
+        try
+        {
+            dte.ExecuteCommand("Debug.Start");
+        }
+        catch (Exception ex)
+        {
+            throw new VsmcpException(ErrorCodes.InteropFault, $"Dump opened, but Debug.Start failed: {ex.Message}", ex);
+        }
+
+        var result = new DumpOpenResult { Path = path };
+        try
+        {
+            var debugger = dte.Debugger;
+            if (debugger is not null)
+            {
+                try { result.FaultingThreadId = debugger.CurrentThread?.ID; } catch { }
+                try
+                {
+                    var expr = debugger.GetExpression("$exception", true, 200);
+                    if (expr is not null && expr.IsValidValue && !string.IsNullOrEmpty(expr.Value))
+                        result.ExceptionMessage = expr.Value;
+                }
+                catch { }
+            }
+        }
+        catch { }
+
+        try { result.ModuleCount = _package.Modules?.Snapshot().Count ?? 0; } catch { }
+        return result;
+    }
+
+    public async Task<DumpSummaryResult> DumpSummaryAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        var debugger = dte.Debugger
+            ?? throw new VsmcpException(ErrorCodes.InteropFault, "DTE.Debugger unavailable.");
+
+        var result = new DumpSummaryResult();
+        result.Mode = debugger.CurrentMode switch
+        {
+            EnvDTE.dbgDebugMode.dbgBreakMode => DebugMode.Break,
+            EnvDTE.dbgDebugMode.dbgRunMode => DebugMode.Run,
+            _ => DebugMode.Design,
+        };
+
+        try
+        {
+            var proc = debugger.CurrentProcess;
+            if (proc is not null)
+            {
+                result.ProcessId = proc.ProcessID;
+                result.ProcessName = proc.Name;
+            }
+        }
+        catch { }
+
+        try
+        {
+            var thread = debugger.CurrentThread;
+            if (thread is not null)
+            {
+                result.FaultingThreadId = thread.ID;
+                result.FaultingThreadName = thread.Name;
+            }
+        }
+        catch { }
+
+        try
+        {
+            var ex = debugger.GetExpression("$exception", true, 200);
+            if (ex is not null && ex.IsValidValue && !string.IsNullOrEmpty(ex.Value))
+                result.ExceptionMessage = ex.Value;
+        }
+        catch { }
+
+        var modules = _package.Modules?.Snapshot();
+        if (modules is not null)
+        {
+            foreach (var m in modules)
+            {
+                result.Modules.Add(m);
+                if (LooksManaged(m)) result.ManagedModuleCount++;
+                else result.NativeModuleCount++;
+            }
+            result.ModuleCount = result.Modules.Count;
+        }
+        return result;
+    }
+
+    public async Task<DumpSaveResult> DumpSaveAsync(DumpSaveOptions options, CancellationToken cancellationToken = default)
+    {
+        if (options is null) throw new VsmcpException(ErrorCodes.NotFound, "Options are required.");
+        if (options.Pid <= 0) throw new VsmcpException(ErrorCodes.NotFound, "Pid must be > 0.");
+        if (string.IsNullOrWhiteSpace(options.Path))
+            throw new VsmcpException(ErrorCodes.NotFound, "Destination path is required.");
+
+        var destPath = Path.GetFullPath(options.Path);
+        var parent = Path.GetDirectoryName(destPath);
+        if (!string.IsNullOrEmpty(parent) && !Directory.Exists(parent))
+            throw new VsmcpException(ErrorCodes.NotFound, $"Parent directory does not exist: {parent}");
+
+        // Dump capture does not touch VS state, so we don't need the UI thread; just run it.
+        return await Task.Run(() => WriteDumpSync(options.Pid, destPath, options.Full), cancellationToken);
+    }
+
+    // -------- helpers --------
+
+    private static DumpSaveResult WriteDumpSync(int pid, string destPath, bool full)
+    {
+        IntPtr processHandle = IntPtr.Zero;
+        FileStream? file = null;
+        try
+        {
+            processHandle = OpenProcess(ProcessAccess.QueryInformation | ProcessAccess.VmRead, false, (uint)pid);
+            if (processHandle == IntPtr.Zero)
+                throw new VsmcpException(ErrorCodes.NotFound, $"OpenProcess({pid}) failed: {new Win32Exception(Marshal.GetLastWin32Error()).Message}");
+
+            file = new FileStream(destPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            var flags = full ? FullDumpFlags : MinidumpFlags;
+            if (!MiniDumpWriteDump(processHandle, (uint)pid, file.SafeFileHandle.DangerousGetHandle(), (uint)flags, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero))
+                throw new VsmcpException(ErrorCodes.InteropFault, $"MiniDumpWriteDump failed: {new Win32Exception(Marshal.GetLastWin32Error()).Message}");
+
+            file.Flush(true);
+            var bytes = file.Length;
+            return new DumpSaveResult { Path = destPath, BytesWritten = bytes, Full = full };
+        }
+        finally
+        {
+            file?.Dispose();
+            if (processHandle != IntPtr.Zero) CloseHandle(processHandle);
+        }
+    }
+
+    private static bool LooksManaged(ModuleInfo m)
+    {
+        // Best-effort classification: managed modules typically end in .dll and show up in the CLR/.NET engine.
+        // We don't have MIF_MANAGED, so fall back to filename heuristics + symbol state hints.
+        var name = m.Name ?? "";
+        if (name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)) return true;
+        if (name.StartsWith("Microsoft.", StringComparison.OrdinalIgnoreCase)) return true;
+        if (name.Equals("mscorlib.dll", StringComparison.OrdinalIgnoreCase)) return true;
+        if (name.Equals("netstandard.dll", StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
+    // -------- P/Invoke (dbghelp + kernel32) --------
+
+    [Flags]
+    private enum ProcessAccess : uint
+    {
+        QueryInformation = 0x0400,
+        VmRead = 0x0010,
+        DupHandle = 0x0040,
+        AllAccess = 0x001F0FFF,
+    }
+
+    // MINIDUMP_TYPE values (subset). Full = comprehensive heap + handle + unloaded + thread info + token + modules.
+    private const uint MinidumpFlags =
+        0x00000000 /* MiniDumpNormal */
+        | 0x00000004 /* WithHandleData */
+        | 0x00000040 /* WithUnloadedModules */
+        | 0x00001000 /* WithThreadInfo */;
+
+    private const uint FullDumpFlags =
+        0x00000002 /* WithFullMemory */
+        | 0x00000004 /* WithHandleData */
+        | 0x00000040 /* WithUnloadedModules */
+        | 0x00000800 /* WithFullMemoryInfo */
+        | 0x00001000 /* WithThreadInfo */
+        | 0x00002000 /* WithCodeSegs */
+        | 0x00040000 /* WithTokenInformation */;
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr OpenProcess(ProcessAccess dwDesiredAccess, bool bInheritHandle, uint dwProcessId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+
+    [DllImport("dbghelp.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool MiniDumpWriteDump(
+        IntPtr hProcess,
+        uint processId,
+        IntPtr hFile,
+        uint dumpType,
+        IntPtr exceptionParam,
+        IntPtr userStreamParam,
+        IntPtr callbackParam);
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -71,6 +71,7 @@
     <Compile Include="RpcTarget.Inspection.cs" />
     <Compile Include="RpcTarget.Modules.cs" />
     <Compile Include="RpcTarget.Memory.cs" />
+    <Compile Include="RpcTarget.Dump.cs" />
     <Compile Include="ModuleTracker.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />


### PR DESCRIPTION
## Summary
- \`dump.open\` loads a .dmp/.mdmp via DTE.ItemOperations.OpenFile + Debug.Start, entering a dump debug session. After the call, the M6 inspection tools (threads/stack/frame/eval/modules) operate on the dump automatically.
- \`dump.summary\` reports faulting thread, exception text (\`\$exception\`), process id/name, and module counts split by managed vs native (heuristic: System.*/Microsoft.*/mscorlib/netstandard → managed).
- \`dump.save\` captures a minidump or full-memory dump of a live process via dbghelp!MiniDumpWriteDump. Defaults to full-memory; set \`full:false\` for a smaller stacks+modules+handles dump.
- \`symbolPath\` / \`sourcePath\` params are accepted but reserved in v1 (VS's configured search paths are used).
- \`dump.dbgeng\` passthrough (\`!analyze -v\` etc.) is deferred — needs a capability-config file under %LOCALAPPDATA%\VSMCP. Partial close on #7.

## Test plan
- [ ] \`dump.open\` on a minidump from a crashed .NET process: VS shows dump summary, Debug.Start enters break mode, \`threads.list\` + \`stack.get\` return source-line info when symbols are configured.
- [ ] \`dump.summary\` reports a non-null \`FaultingThreadId\` and populates \`ExceptionMessage\` when the dump carries an exception record.
- [ ] \`dump.save\` on a live PID writes a .dmp whose size matches \`BytesWritten\`; \`dump.open\` on the resulting file succeeds.
- [ ] \`dump.save\` fails cleanly on a PID owned by another user or with insufficient rights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)