### PR TITLE
M8 (first pass): processes.list + counters.get

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -731,4 +731,26 @@ public sealed class VsmcpTools
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.DumpSaveAsync(new DumpSaveOptions { Pid = pid, Path = path, Full = full }, ct).ConfigureAwait(false);
     }
+
+    [McpServerTool(Name = "processes.list")]
+    [Description("Enumerate local processes visible to devenv.exe. Useful for picking a PID before debug.attach, dump.save, or counters.get. By default restricts to devenv's Windows session.")]
+    public async Task<ProcessListResult> ProcessesList(
+        [Description("Case-insensitive substring filter on process name. Null = no filter.")] string? nameContains = null,
+        [Description("When true (default), only processes in the same Windows session as Visual Studio are returned.")] bool currentSessionOnly = true,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.ProcessesListAsync(new ProcessListFilter { NameContains = nameContains, CurrentSessionOnly = currentSessionOnly }, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "counters.get")]
+    [Description("One-shot snapshot of process-level counters: CPU% (sampled across `sampleMs`), working set, private/virtual memory, thread/handle counts, and uptime. Uses System.Diagnostics.Process — no profiler attachment required. For streaming counters, see a future counters.subscribe.")]
+    public async Task<CountersSnapshot> CountersGet(
+        [Description("Target process id.")] int pid,
+        [Description("Sampling window in milliseconds for CPU% (clamped to 50..10000). Default 200ms.")] int sampleMs = 200,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.CountersGetAsync(pid, sampleMs, ct).ConfigureAwait(false);
+    }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -98,4 +98,8 @@ public interface IVsmcpRpc
     Task<DumpOpenResult> DumpOpenAsync(DumpOpenOptions options, CancellationToken cancellationToken = default);
     Task<DumpSummaryResult> DumpSummaryAsync(CancellationToken cancellationToken = default);
     Task<DumpSaveResult> DumpSaveAsync(DumpSaveOptions options, CancellationToken cancellationToken = default);
+
+    // -------- Diagnostics (counters + process enumeration) --------
+    Task<ProcessListResult> ProcessesListAsync(ProcessListFilter? filter, CancellationToken cancellationToken = default);
+    Task<CountersSnapshot> CountersGetAsync(int pid, int sampleMs, CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M8Dtos.cs
+++ b/src/VSMCP.Shared/M8Dtos.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public sealed class ProcessListFilter
+{
+    /// <summary>Substring match against process name (case-insensitive). Null = no filter.</summary>
+    public string? NameContains { get; set; }
+    /// <summary>When true, only processes owned by the same Windows session as devenv.exe are returned.</summary>
+    public bool CurrentSessionOnly { get; set; } = true;
+}
+
+public sealed class ProcessInfoRow
+{
+    public int Pid { get; set; }
+    public string Name { get; set; } = "";
+    public int SessionId { get; set; }
+    public long WorkingSetBytes { get; set; }
+    public long PrivateMemoryBytes { get; set; }
+    public int ThreadCount { get; set; }
+    /// <summary>Path to the main module when readable; null for protected processes (lsass, system, etc.).</summary>
+    public string? MainModulePath { get; set; }
+    /// <summary>ISO-8601 UTC start time, null if inaccessible.</summary>
+    public string? StartedUtc { get; set; }
+}
+
+public sealed class ProcessListResult
+{
+    public List<ProcessInfoRow> Processes { get; set; } = new();
+    /// <summary>Count of processes skipped because of access denied (usually elevated/system processes).</summary>
+    public int Inaccessible { get; set; }
+}
+
+public sealed class CountersSnapshot
+{
+    public int Pid { get; set; }
+    public string Name { get; set; } = "";
+    /// <summary>Sampling window in milliseconds used to compute <see cref="CpuPercent"/>.</summary>
+    public int SampleMs { get; set; }
+    /// <summary>CPU usage across the sampling window, as a percentage of one logical core (0..100 * logicalCpuCount).</summary>
+    public double CpuPercent { get; set; }
+    /// <summary>CPU usage normalized to total machine CPU (0..100 regardless of core count).</summary>
+    public double CpuPercentNormalized { get; set; }
+    public long WorkingSetBytes { get; set; }
+    public long PrivateMemoryBytes { get; set; }
+    public long VirtualMemoryBytes { get; set; }
+    public long PagedMemoryBytes { get; set; }
+    public int ThreadCount { get; set; }
+    public int HandleCount { get; set; }
+    /// <summary>Total CPU time accumulated since process start, milliseconds.</summary>
+    public long TotalCpuTimeMs { get; set; }
+    public long UptimeMs { get; set; }
+    public int LogicalProcessorCount { get; set; }
+}

--- a/src/VSMCP.Vsix/RpcTarget.Diagnostics.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Diagnostics.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using VSMCP.Shared;
+using Process = System.Diagnostics.Process;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public Task<ProcessListResult> ProcessesListAsync(ProcessListFilter? filter, CancellationToken cancellationToken = default)
+    {
+        filter ??= new ProcessListFilter();
+        var result = new ProcessListResult();
+        var currentSession = Process.GetCurrentProcess().SessionId;
+        var needle = filter.NameContains;
+
+        foreach (var p in Process.GetProcesses())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                if (filter.CurrentSessionOnly && p.SessionId != currentSession) { p.Dispose(); continue; }
+                if (!string.IsNullOrEmpty(needle) && p.ProcessName.IndexOf(needle!, StringComparison.OrdinalIgnoreCase) < 0)
+                {
+                    p.Dispose();
+                    continue;
+                }
+
+                var row = new ProcessInfoRow
+                {
+                    Pid = p.Id,
+                    Name = p.ProcessName,
+                    SessionId = p.SessionId,
+                };
+
+                try { row.WorkingSetBytes = p.WorkingSet64; } catch { }
+                try { row.PrivateMemoryBytes = p.PrivateMemorySize64; } catch { }
+                try { row.ThreadCount = p.Threads.Count; } catch { }
+                try { row.MainModulePath = p.MainModule?.FileName; } catch { /* protected process */ }
+                try { row.StartedUtc = p.StartTime.ToUniversalTime().ToString("o"); } catch { }
+
+                result.Processes.Add(row);
+            }
+            catch
+            {
+                result.Inaccessible++;
+            }
+            finally
+            {
+                p.Dispose();
+            }
+        }
+
+        result.Processes.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(result);
+    }
+
+    public async Task<CountersSnapshot> CountersGetAsync(int pid, int sampleMs, CancellationToken cancellationToken = default)
+    {
+        if (pid <= 0) throw new VsmcpException(ErrorCodes.NotFound, "Pid must be > 0.");
+        if (sampleMs < 50) sampleMs = 50;
+        if (sampleMs > 10_000) sampleMs = 10_000;
+
+        Process process;
+        try { process = Process.GetProcessById(pid); }
+        catch (ArgumentException) { throw new VsmcpException(ErrorCodes.NotFound, $"No process with pid {pid}."); }
+        catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Cannot open pid {pid}: {ex.Message}", ex); }
+
+        try
+        {
+            var logicalCpus = Environment.ProcessorCount;
+            TimeSpan cpu1;
+            try { cpu1 = process.TotalProcessorTime; }
+            catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Cannot read CPU time for pid {pid} (rights?): {ex.Message}", ex); }
+            var t1 = DateTime.UtcNow;
+
+            await Task.Delay(sampleMs, cancellationToken).ConfigureAwait(false);
+
+            process.Refresh();
+            TimeSpan cpu2;
+            try { cpu2 = process.TotalProcessorTime; }
+            catch (Exception ex) { throw new VsmcpException(ErrorCodes.InteropFault, $"Cannot read CPU time (second sample) for pid {pid}: {ex.Message}", ex); }
+            var t2 = DateTime.UtcNow;
+
+            var wallMs = (t2 - t1).TotalMilliseconds;
+            var cpuMsDelta = (cpu2 - cpu1).TotalMilliseconds;
+            var perCore = wallMs > 0 ? (cpuMsDelta / wallMs) * 100.0 : 0.0;
+            var normalized = logicalCpus > 0 ? perCore / logicalCpus : perCore;
+
+            var snap = new CountersSnapshot
+            {
+                Pid = pid,
+                Name = process.ProcessName,
+                SampleMs = sampleMs,
+                CpuPercent = perCore,
+                CpuPercentNormalized = normalized,
+                LogicalProcessorCount = logicalCpus,
+                TotalCpuTimeMs = (long)cpu2.TotalMilliseconds,
+            };
+
+            try { snap.WorkingSetBytes = process.WorkingSet64; } catch { }
+            try { snap.PrivateMemoryBytes = process.PrivateMemorySize64; } catch { }
+            try { snap.VirtualMemoryBytes = process.VirtualMemorySize64; } catch { }
+            try { snap.PagedMemoryBytes = process.PagedMemorySize64; } catch { }
+            try { snap.ThreadCount = process.Threads.Count; } catch { }
+            try { snap.HandleCount = process.HandleCount; } catch { }
+            try { snap.UptimeMs = (long)(DateTime.Now - process.StartTime).TotalMilliseconds; } catch { }
+
+            return snap;
+        }
+        finally
+        {
+            process.Dispose();
+        }
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -72,6 +72,7 @@
     <Compile Include="RpcTarget.Modules.cs" />
     <Compile Include="RpcTarget.Memory.cs" />
     <Compile Include="RpcTarget.Dump.cs" />
+    <Compile Include="RpcTarget.Diagnostics.cs" />
     <Compile Include="ModuleTracker.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />


### PR DESCRIPTION
## Summary
First pass at M8 diagnostics. Ships two lightweight tools that are genuinely useful on their own; heavier items stay open on #8.

- \`processes.list(nameContains?, currentSessionOnly=true)\` — enumerate local processes with pid/name/session id/working set/private memory/thread count/main module path. Useful before \`debug.attach\`, \`dump.save\`, or \`counters.get\`.
- \`counters.get(pid, sampleMs=200)\` — one-shot process counters: CPU% (per-core and normalized), working set, private/virtual/paged memory, thread and handle counts, total CPU time, uptime. Uses \`System.Diagnostics.Process\` with a dual-sample delta for CPU%.

## Deferred (still open on #8)
- \`profiler.start/stop/report\` — needs Microsoft.DiagnosticsHub.* interop and a \`.diagsession\` parser.
- \`counters.subscribe\` — needs push-notification infra layered over the pipe RPC.
- \`trace.collect\` — needs TraceEvent dependency + admin; likely best implemented server-side rather than in the VSIX.

## Test plan
- [ ] \`processes.list\` returns \>0 rows; every row has a pid and name; \`currentSessionOnly=true\` filters out System/services session.
- [ ] \`processes.list(nameContains='dev')\` narrows to devenv etc.
- [ ] \`counters.get(devenv pid, 500)\` returns a plausible CPU% (near 0 at idle; \>0 when VS is doing work) and non-zero WorkingSetBytes.
- [ ] \`counters.get\` on a non-existent pid returns a VSMCP-not-found error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)