### PR TITLE
M8b: profiler.start/stop/report via EventPipe (closes #8)

### DIFF
--- a/src/VSMCP.Server/ProfilerHost.cs
+++ b/src/VSMCP.Server/ProfilerHost.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Diagnostics.Tracing.Stacks;
+using VSMCP.Shared;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// Owns EventPipe profiling sessions. Sessions are identified by a GUID string;
+/// the raw .nettrace is streamed to a file while the session runs.
+/// </summary>
+public sealed class ProfilerHost : IDisposable
+{
+    private readonly ConcurrentDictionary<string, ActiveSession> _sessions = new(StringComparer.Ordinal);
+
+    public ProfilerStartResult Start(int pid, ProfilerMode mode, string? outputPath)
+    {
+        if (pid <= 0) throw new ArgumentOutOfRangeException(nameof(pid), "Pid must be > 0.");
+
+        var outPath = string.IsNullOrWhiteSpace(outputPath)
+            ? Path.Combine(Path.GetTempPath(), $"vsmcp-{DateTime.UtcNow:yyyyMMdd-HHmmss}-{pid}-{mode}.nettrace")
+            : Path.GetFullPath(outputPath!);
+        var parent = Path.GetDirectoryName(outPath);
+        if (!string.IsNullOrEmpty(parent) && !Directory.Exists(parent))
+            throw new DirectoryNotFoundException($"Parent directory does not exist: {parent}");
+
+        var providers = BuildProviders(mode);
+        var client = new DiagnosticsClient(pid);
+        EventPipeSession session;
+        try
+        {
+            session = client.StartEventPipeSession(providers, requestRundown: true);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to start EventPipe session on pid {pid}. Target must be a running .NET 5+ process reachable over the diagnostic port. Inner: {ex.Message}", ex);
+        }
+
+        var sessionId = Guid.NewGuid().ToString("N");
+        var started = DateTimeOffset.UtcNow;
+
+        var stream = new FileStream(outPath, FileMode.Create, FileAccess.Write, FileShare.Read);
+        var cts = new CancellationTokenSource();
+        var copyTask = Task.Run(async () =>
+        {
+            try
+            {
+                await session.EventStream.CopyToAsync(stream, 64 * 1024, cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { /* normal on stop */ }
+            catch (Exception) { /* swallow; caller inspects file size */ }
+            finally
+            {
+                await stream.FlushAsync().ConfigureAwait(false);
+                stream.Dispose();
+            }
+        }, cts.Token);
+
+        _sessions[sessionId] = new ActiveSession(sessionId, pid, mode, outPath, started, session, copyTask, cts);
+
+        return new ProfilerStartResult
+        {
+            SessionId = sessionId,
+            Pid = pid,
+            Mode = mode,
+            OutputPath = outPath,
+            StartedUtc = started.ToString("o"),
+        };
+    }
+
+    public async Task<ProfilerStopResult> StopAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        if (!_sessions.TryRemove(sessionId, out var s))
+            throw new InvalidOperationException($"No active profiler session with id '{sessionId}'.");
+
+        try { s.Session.Stop(); } catch { /* session may already be closing */ }
+        try { await s.CopyTask.WaitAsync(cancellationToken).ConfigureAwait(false); } catch { }
+        s.CancelTokenSource.Dispose();
+        s.Session.Dispose();
+
+        long size = 0;
+        try { size = new FileInfo(s.OutputPath).Length; } catch { }
+
+        return new ProfilerStopResult
+        {
+            SessionId = sessionId,
+            OutputPath = s.OutputPath,
+            BytesWritten = size,
+            DurationSeconds = (DateTimeOffset.UtcNow - s.StartedUtc).TotalSeconds,
+        };
+    }
+
+    public ProfilerReport Report(string tracePath, int top)
+    {
+        if (string.IsNullOrWhiteSpace(tracePath)) throw new ArgumentException("Trace path is required.", nameof(tracePath));
+        tracePath = Path.GetFullPath(tracePath);
+        if (!File.Exists(tracePath)) throw new FileNotFoundException("Trace file not found.", tracePath);
+        if (top <= 0) top = 20;
+        if (top > 1000) top = 1000;
+
+        var report = new ProfilerReport { Path = tracePath };
+
+        string etlx;
+        try
+        {
+            etlx = TraceLog.CreateFromEventPipeDataFile(tracePath);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Could not convert .nettrace to TraceLog: {ex.Message}", ex);
+        }
+
+        using var traceLog = new TraceLog(etlx);
+        report.DurationSeconds = traceLog.SessionDuration.TotalSeconds;
+
+        // Aggregate CPU samples by leaf method. ClrSamplingProfilerSampledProfile events carry a CallStackIndex
+        // that TraceLog can resolve; the leaf (top of stack) is the self-time bucket for that sample.
+        var byMethod = new Dictionary<string, (long count, string module)>(StringComparer.Ordinal);
+        long total = 0;
+
+        foreach (var ev in traceLog.Events)
+        {
+            // Sample profiler events show up in traceLog as generic events when parsed through EventPipe;
+            // match by TaskName to stay provider-agnostic.
+            if (ev.ProviderName != "Microsoft-DotNETCore-SampleProfiler") continue;
+            if (ev.EventName != "Thread/Sample") continue;
+
+            var callStack = ev.CallStack();
+            if (callStack is null) continue;
+
+            var method = callStack.CodeAddress.Method;
+            var name = method?.FullMethodName ?? ("0x" + callStack.CodeAddress.Address.ToString("X"));
+            var module = method?.MethodModuleFile?.Name ?? "?";
+            if (byMethod.TryGetValue(name, out var prev))
+                byMethod[name] = (prev.count + 1, module);
+            else
+                byMethod[name] = (1, module);
+            total++;
+        }
+
+        report.TotalSamples = total;
+        if (total == 0)
+        {
+            report.Empty = true;
+            return report;
+        }
+
+        var ordered = new List<KeyValuePair<string, (long count, string module)>>(byMethod);
+        ordered.Sort((a, b) => b.Value.count.CompareTo(a.Value.count));
+        for (int i = 0; i < Math.Min(top, ordered.Count); i++)
+        {
+            var e = ordered[i];
+            report.Hot.Add(new HotFunction
+            {
+                FunctionName = e.Key,
+                Module = e.Value.module,
+                SampleCount = e.Value.count,
+                PercentOfSamples = 100.0 * e.Value.count / total,
+            });
+        }
+        return report;
+    }
+
+    public IReadOnlyList<string> ActiveSessionIds()
+    {
+        var keys = new List<string>(_sessions.Keys);
+        keys.Sort(StringComparer.Ordinal);
+        return keys;
+    }
+
+    public void Dispose()
+    {
+        foreach (var kv in _sessions)
+        {
+            try { kv.Value.CancelTokenSource.Cancel(); } catch { }
+            try { kv.Value.Session.Dispose(); } catch { }
+        }
+        _sessions.Clear();
+    }
+
+    private static List<EventPipeProvider> BuildProviders(ProfilerMode mode) => mode switch
+    {
+        ProfilerMode.CpuSampling => new List<EventPipeProvider>
+        {
+            new("Microsoft-DotNETCore-SampleProfiler", EventLevel.Informational),
+            new("Microsoft-Windows-DotNETRuntime", EventLevel.Informational,
+                (long)(ClrTraceEventParser.Keywords.Loader | ClrTraceEventParser.Keywords.Jit | ClrTraceEventParser.Keywords.JittedMethodILToNativeMap | ClrTraceEventParser.Keywords.NGen | ClrTraceEventParser.Keywords.Stack)),
+        },
+        ProfilerMode.Allocations => new List<EventPipeProvider>
+        {
+            new("Microsoft-Windows-DotNETRuntime", EventLevel.Informational,
+                (long)(ClrTraceEventParser.Keywords.GC | ClrTraceEventParser.Keywords.GCSampledObjectAllocationHigh | ClrTraceEventParser.Keywords.Type | ClrTraceEventParser.Keywords.Stack)),
+        },
+        _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "Unknown profiler mode."),
+    };
+
+    private sealed record ActiveSession(
+        string SessionId,
+        int Pid,
+        ProfilerMode Mode,
+        string OutputPath,
+        DateTimeOffset StartedUtc,
+        EventPipeSession Session,
+        Task CopyTask,
+        CancellationTokenSource CancelTokenSource);
+}

--- a/src/VSMCP.Server/Program.cs
+++ b/src/VSMCP.Server/Program.cs
@@ -11,6 +11,7 @@ builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
 builder.Logging.SetMinimumLevel(LogLevel.Warning);
 
 builder.Services.AddSingleton<VsConnection>();
+builder.Services.AddSingleton<ProfilerHost>();
 
 builder.Services
     .AddMcpServer()

--- a/src/VSMCP.Server/VSMCP.Server.csproj
+++ b/src/VSMCP.Server/VSMCP.Server.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.607501" />
+    <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.16" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VSMCP.Shared\VSMCP.Shared.csproj" />

--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -16,8 +16,13 @@ namespace VSMCP.Server;
 public sealed class VsmcpTools
 {
     private readonly VsConnection _connection;
+    private readonly ProfilerHost _profiler;
 
-    public VsmcpTools(VsConnection connection) => _connection = connection;
+    public VsmcpTools(VsConnection connection, ProfilerHost profiler)
+    {
+        _connection = connection;
+        _profiler = profiler;
+    }
 
     [McpServerTool(Name = "ping")]
     [Description("Round-trip ping to the connected Visual Studio instance. Returns 'pong' and a server-side timestamp.")]
@@ -744,7 +749,7 @@ public sealed class VsmcpTools
     }
 
     [McpServerTool(Name = "counters.get")]
-    [Description("One-shot snapshot of process-level counters: CPU% (sampled across `sampleMs`), working set, private/virtual memory, thread/handle counts, and uptime. Uses System.Diagnostics.Process — no profiler attachment required. For streaming counters, see a future counters.subscribe.")]
+    [Description("One-shot snapshot of process-level counters: CPU% (sampled across `sampleMs`), working set, private/virtual memory, thread/handle counts, and uptime. Uses System.Diagnostics.Process — no profiler attachment required. Poll this from the MCP client to build a timeline.")]
     public async Task<CountersSnapshot> CountersGet(
         [Description("Target process id.")] int pid,
         [Description("Sampling window in milliseconds for CPU% (clamped to 50..10000). Default 200ms.")] int sampleMs = 200,
@@ -752,5 +757,35 @@ public sealed class VsmcpTools
     {
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.CountersGetAsync(pid, sampleMs, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "profiler.start")]
+    [Description("Start an EventPipe profiling session against a .NET 5+ process. Returns a session id and an output path; the .nettrace is streamed to that file until profiler.stop is called. Does not require Visual Studio to be running or attached. Modes: CpuSampling (default) captures CPU samples + JIT map; Allocations captures sampled object allocations + GC.")]
+    public Task<ProfilerStartResult> ProfilerStart(
+        [Description("Target process id. Must be a running .NET 5+ process reachable via its diagnostic port.")] int pid,
+        [Description("Profiler mode. 0 = CpuSampling (default), 1 = Allocations.")] ProfilerMode mode = ProfilerMode.CpuSampling,
+        [Description("Optional absolute output path for the .nettrace. Default: %TEMP%\\vsmcp-<ts>-<pid>-<mode>.nettrace.")] string? outputPath = null,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(_profiler.Start(pid, mode, outputPath));
+    }
+
+    [McpServerTool(Name = "profiler.stop")]
+    [Description("Stop a running EventPipe session by id. Flushes the .nettrace to disk and returns the final file size and wall-clock duration.")]
+    public async Task<ProfilerStopResult> ProfilerStop(
+        [Description("Session id from profiler.start.")] string sessionId,
+        CancellationToken ct = default)
+    {
+        return await _profiler.StopAsync(sessionId, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "profiler.report")]
+    [Description("Summarize a .nettrace file: total sample count, session duration, and the top N hot functions by self-time (leaf-of-stack) sample count. Uses Microsoft.Diagnostics.Tracing.TraceEvent; symbols come from whatever is on disk or in the trace's JIT rundown.")]
+    public Task<ProfilerReport> ProfilerReport(
+        [Description("Absolute path to a .nettrace file (from profiler.stop).")] string path,
+        [Description("Max number of hot functions to return (1..1000, default 20).")] int top = 20,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(_profiler.Report(path, top));
     }
 }

--- a/src/VSMCP.Shared/M8bDtos.cs
+++ b/src/VSMCP.Shared/M8bDtos.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public enum ProfilerMode
+{
+    CpuSampling = 0,
+    Allocations = 1,
+}
+
+public sealed class ProfilerStartResult
+{
+    public string SessionId { get; set; } = "";
+    public int Pid { get; set; }
+    public ProfilerMode Mode { get; set; }
+    public string OutputPath { get; set; } = "";
+    public string StartedUtc { get; set; } = "";
+}
+
+public sealed class ProfilerStopResult
+{
+    public string SessionId { get; set; } = "";
+    public string OutputPath { get; set; } = "";
+    public long BytesWritten { get; set; }
+    public double DurationSeconds { get; set; }
+}
+
+public sealed class HotFunction
+{
+    public string Module { get; set; } = "";
+    public string FunctionName { get; set; } = "";
+    public long SampleCount { get; set; }
+    public double PercentOfSamples { get; set; }
+}
+
+public sealed class ProfilerReport
+{
+    public string Path { get; set; } = "";
+    public long TotalSamples { get; set; }
+    public double DurationSeconds { get; set; }
+    public List<HotFunction> Hot { get; set; } = new();
+    /// <summary>True when the trace was unresolvable (wrong format, empty, truncated).</summary>
+    public bool Empty { get; set; }
+}


### PR DESCRIPTION
## Summary
Finishes M8. These tools live in VSMCP.Server (bypass the VSIX proxy) and only need a .NET 5+ target's diagnostic port — Visual Studio doesn't have to be running.

- \`profiler.start(pid, mode, outputPath?)\` opens an EventPipe session via Microsoft.Diagnostics.NETCore.Client and streams the .nettrace to disk. Modes:
  - \`CpuSampling\` (default): Microsoft-DotNETCore-SampleProfiler + JIT rundown keywords.
  - \`Allocations\`: DotNETRuntime GC + GCSampledObjectAllocationHigh + Type + Stack keywords.
- \`profiler.stop(sessionId)\` flushes the session, returns final file size + wall-clock duration.
- \`profiler.report(path, top=20)\` opens the .nettrace via TraceEvent's TraceLog, aggregates \`Thread/Sample\` events by leaf method, and returns self-time hot functions with percent-of-total-samples.

## Deferred (deliberately — noted in issue follow-ups)
- \`counters.subscribe\` — MCP has no push-notification model. The equivalent is polling \`counters.get\` from the client. Not worth adding a custom channel right now.
- \`trace.collect\` (kernel ETW) — EventPipe profiling covers the common need without admin rights. Will revisit if a use case surfaces that specifically requires kernel providers.

Closes #8.

## Test plan
- [ ] \`profiler.start\` against a long-running .NET 8 console app returns a session id and creates the .nettrace file.
- [ ] While running, the file grows; \`profiler.stop\` returns \`BytesWritten\` matching file size on disk.
- [ ] \`profiler.report\` on the resulting .nettrace returns a non-empty \`Hot\` list and \`TotalSamples > 0\`.
- [ ] \`profiler.start\` on a non-.NET process (e.g. notepad) returns a clean error, not a crash.
- [ ] Allocation mode on an allocating fixture returns a non-empty report (even if hot-function aggregation is coarse for allocation events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)