### PR TITLE
M9: Roslyn-backed code intelligence

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -788,4 +788,58 @@ public sealed class VsmcpTools
     {
         return Task.FromResult(_profiler.Report(path, top));
     }
+
+    // -------- Code intelligence (Roslyn) --------
+
+    [McpServerTool(Name = "code.symbols")]
+    [Description("Return the document outline for a file: namespaces, types, and members with 1-based source spans. Requires the file to belong to a project loaded in the current solution. Works on any Roslyn-backed language (C#, VB).")]
+    public async Task<SymbolsResult> CodeSymbols(
+        [Description("Absolute path to the source file.")] string file,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.CodeSymbolsAsync(file, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "code.goto_definition")]
+    [Description("Resolve the symbol at a 1-based (line, column) and return its declaration location(s). Returns an empty Locations list when no symbol is at the position. Metadata definitions are skipped (only in-source locations are returned).")]
+    public async Task<LocationListResult> CodeGotoDefinition(
+        [Description("Source position: { File, Line (1-based), Column (1-based) }.")] CodePosition position,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.CodeGotoDefinitionAsync(position, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "code.find_references")]
+    [Description("Find all references (across the solution) to the symbol at a 1-based (line, column). Returns definition locations plus up to `maxResults` reference spans; sets Truncated when more exist.")]
+    public async Task<ReferencesResult> CodeFindReferences(
+        [Description("Source position: { File, Line (1-based), Column (1-based) }.")] CodePosition position,
+        [Description("Max number of reference spans to return (1..5000, default 500).")] int maxResults = 500,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.CodeFindReferencesAsync(position, maxResults, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "code.diagnostics")]
+    [Description("Report Roslyn diagnostics (errors, warnings, info) for a single file or the whole solution, without invoking MSBuild. When `file` is null/empty the whole solution is scanned (can be slow on large repos).")]
+    public async Task<DiagnosticsResult> CodeDiagnostics(
+        [Description("Absolute path to a file. Omit or empty to scan the whole solution.")] string? file = null,
+        [Description("Max number of diagnostics to return (1..10000, default 500).")] int maxResults = 500,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.CodeDiagnosticsAsync(file, maxResults, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "code.quick_info")]
+    [Description("Return quick-info for the symbol at a 1-based (line, column): display-form signature, kind, and documentation XML (if any). Returns an empty result when no symbol is at the position.")]
+    public async Task<QuickInfoResult> CodeQuickInfo(
+        [Description("Source position: { File, Line (1-based), Column (1-based) }.")] CodePosition position,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.CodeQuickInfoAsync(position, ct).ConfigureAwait(false);
+    }
 }

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -102,4 +102,11 @@ public interface IVsmcpRpc
     // -------- Diagnostics (counters + process enumeration) --------
     Task<ProcessListResult> ProcessesListAsync(ProcessListFilter? filter, CancellationToken cancellationToken = default);
     Task<CountersSnapshot> CountersGetAsync(int pid, int sampleMs, CancellationToken cancellationToken = default);
+
+    // -------- Code intelligence (Roslyn) --------
+    Task<SymbolsResult> CodeSymbolsAsync(string file, CancellationToken cancellationToken = default);
+    Task<LocationListResult> CodeGotoDefinitionAsync(CodePosition position, CancellationToken cancellationToken = default);
+    Task<ReferencesResult> CodeFindReferencesAsync(CodePosition position, int maxResults, CancellationToken cancellationToken = default);
+    Task<DiagnosticsResult> CodeDiagnosticsAsync(string? file, int maxResults, CancellationToken cancellationToken = default);
+    Task<QuickInfoResult> CodeQuickInfoAsync(CodePosition position, CancellationToken cancellationToken = default);
 }

--- a/src/VSMCP.Shared/M9Dtos.cs
+++ b/src/VSMCP.Shared/M9Dtos.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+public sealed class CodePosition
+{
+    public string File { get; set; } = "";
+    /// <summary>1-based line number.</summary>
+    public int Line { get; set; }
+    /// <summary>1-based column number.</summary>
+    public int Column { get; set; }
+}
+
+public sealed class CodeSpan
+{
+    public string File { get; set; } = "";
+    public int StartLine { get; set; }
+    public int StartColumn { get; set; }
+    public int EndLine { get; set; }
+    public int EndColumn { get; set; }
+    /// <summary>Optional snippet of the spanned text (trimmed/truncated).</summary>
+    public string? Text { get; set; }
+}
+
+public sealed class CodeSymbol
+{
+    public string Name { get; set; } = "";
+    /// <summary>Roslyn SymbolKind (Namespace, NamedType, Method, Property, Field, Event, Parameter, Local).</summary>
+    public string Kind { get; set; } = "";
+    /// <summary>Fully qualified name of the container (e.g. "Namespace.Class").</summary>
+    public string? ContainerName { get; set; }
+    public string? Signature { get; set; }
+    public CodeSpan? Location { get; set; }
+    public List<CodeSymbol> Children { get; set; } = new();
+}
+
+public sealed class SymbolsResult
+{
+    public string File { get; set; } = "";
+    public List<CodeSymbol> Symbols { get; set; } = new();
+    public string? Language { get; set; }
+}
+
+public sealed class LocationListResult
+{
+    public List<CodeSpan> Locations { get; set; } = new();
+    public CodeSymbol? Symbol { get; set; }
+}
+
+public sealed class ReferencesResult
+{
+    public CodeSymbol? Symbol { get; set; }
+    public List<CodeSpan> Definitions { get; set; } = new();
+    public List<CodeSpan> References { get; set; } = new();
+    public int TotalReferences { get; set; }
+    public bool Truncated { get; set; }
+}
+
+public enum CodeDiagnosticSeverity
+{
+    Hidden = 0,
+    Info = 1,
+    Warning = 2,
+    Error = 3,
+}
+
+public sealed class CodeDiagnosticInfo
+{
+    public string Id { get; set; } = "";
+    public CodeDiagnosticSeverity Severity { get; set; }
+    public string Message { get; set; } = "";
+    public string? Category { get; set; }
+    public CodeSpan? Location { get; set; }
+}
+
+public sealed class DiagnosticsResult
+{
+    public List<CodeDiagnosticInfo> Diagnostics { get; set; } = new();
+    public int TotalDiagnostics { get; set; }
+    public bool Truncated { get; set; }
+    /// <summary>Files that contributed — useful when scope is the whole solution.</summary>
+    public List<string> FilesScanned { get; set; } = new();
+}
+
+public sealed class QuickInfoResult
+{
+    public string? Signature { get; set; }
+    public string? Documentation { get; set; }
+    public string? Kind { get; set; }
+    public CodeSymbol? Symbol { get; set; }
+}

--- a/src/VSMCP.Vsix/RpcTarget.Code.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Code.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.LanguageServices;
+using Microsoft.VisualStudio.Shell;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    private async Task<VisualStudioWorkspace> GetWorkspaceAsync(CancellationToken ct)
+    {
+        await _jtf.SwitchToMainThreadAsync(ct);
+        if (await _package.GetServiceAsync(typeof(SComponentModel)) is not IComponentModel cm)
+            throw new VsmcpException(ErrorCodes.InteropFault, "IComponentModel unavailable.");
+        var ws = cm.GetService<VisualStudioWorkspace>()
+            ?? throw new VsmcpException(ErrorCodes.InteropFault, "VisualStudioWorkspace unavailable.");
+        return ws;
+    }
+
+    private static Document? FindDocument(Solution solution, string filePath)
+    {
+        var full = System.IO.Path.GetFullPath(filePath);
+        var id = solution.GetDocumentIdsWithFilePath(full).FirstOrDefault();
+        return id is null ? null : solution.GetDocument(id);
+    }
+
+    private static int PositionFromLineCol(SourceText text, int line, int column)
+    {
+        if (line < 1) line = 1;
+        if (column < 1) column = 1;
+        var lineIndex = Math.Min(line - 1, text.Lines.Count - 1);
+        var ln = text.Lines[lineIndex];
+        var col = Math.Min(column - 1, ln.End - ln.Start);
+        return ln.Start + col;
+    }
+
+    private static CodeSpan SpanFromLocation(Location loc)
+    {
+        var span = loc.GetLineSpan();
+        return new CodeSpan
+        {
+            File = span.Path ?? "",
+            StartLine = span.StartLinePosition.Line + 1,
+            StartColumn = span.StartLinePosition.Character + 1,
+            EndLine = span.EndLinePosition.Line + 1,
+            EndColumn = span.EndLinePosition.Character + 1,
+        };
+    }
+
+    private static CodeSymbol ToCodeSymbol(ISymbol symbol)
+    {
+        var cs = new CodeSymbol
+        {
+            Name = symbol.Name,
+            Kind = symbol.Kind.ToString(),
+            ContainerName = symbol.ContainingSymbol?.ToDisplayString(),
+            Signature = symbol.ToDisplayString(),
+        };
+        var loc = symbol.Locations.FirstOrDefault(l => l.IsInSource);
+        if (loc is not null) cs.Location = SpanFromLocation(loc);
+        return cs;
+    }
+
+    public async Task<SymbolsResult> CodeSymbolsAsync(string file, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(file)) throw new VsmcpException(ErrorCodes.NotFound, "file is required.");
+        var ws = await GetWorkspaceAsync(cancellationToken);
+        var doc = FindDocument(ws.CurrentSolution, file)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"File not part of any loaded project: {file}");
+
+        var result = new SymbolsResult { File = file, Language = doc.Project.Language };
+        var root = await doc.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        var sm = await doc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null || sm is null) return result;
+
+        foreach (var node in root.ChildNodes())
+            WalkOutline(node, sm, result.Symbols, cancellationToken);
+        return result;
+    }
+
+    private static void WalkOutline(SyntaxNode node, SemanticModel sm, List<CodeSymbol> into, CancellationToken ct)
+    {
+        ct.ThrowIfCancellationRequested();
+        switch (node)
+        {
+            case BaseNamespaceDeclarationSyntax ns:
+            {
+                var nsSym = sm.GetDeclaredSymbol(ns);
+                var entry = nsSym is not null ? ToCodeSymbol(nsSym) : new CodeSymbol { Name = ns.Name.ToString(), Kind = "Namespace" };
+                entry.Location ??= SpanFromLocation(ns.GetLocation());
+                foreach (var c in ns.ChildNodes()) WalkOutline(c, sm, entry.Children, ct);
+                into.Add(entry);
+                return;
+            }
+            case BaseTypeDeclarationSyntax type:
+            {
+                var sym = sm.GetDeclaredSymbol(type);
+                var entry = sym is not null ? ToCodeSymbol(sym) : new CodeSymbol { Name = type.Identifier.Text, Kind = "NamedType" };
+                entry.Location ??= SpanFromLocation(type.GetLocation());
+                foreach (var member in type.ChildNodes()) WalkOutline(member, sm, entry.Children, ct);
+                into.Add(entry);
+                return;
+            }
+            case DelegateDeclarationSyntax del:
+            {
+                var sym = sm.GetDeclaredSymbol(del);
+                if (sym is not null) into.Add(ToCodeSymbol(sym));
+                return;
+            }
+            case BaseMethodDeclarationSyntax m:
+            {
+                var sym = sm.GetDeclaredSymbol(m);
+                if (sym is not null) into.Add(ToCodeSymbol(sym));
+                return;
+            }
+            case PropertyDeclarationSyntax p:
+            {
+                var sym = sm.GetDeclaredSymbol(p);
+                if (sym is not null) into.Add(ToCodeSymbol(sym));
+                return;
+            }
+            case EventDeclarationSyntax ev:
+            {
+                var sym = sm.GetDeclaredSymbol(ev);
+                if (sym is not null) into.Add(ToCodeSymbol(sym));
+                return;
+            }
+            case FieldDeclarationSyntax fld:
+            {
+                foreach (var v in fld.Declaration.Variables)
+                {
+                    var sym = sm.GetDeclaredSymbol(v);
+                    if (sym is not null) into.Add(ToCodeSymbol(sym));
+                }
+                return;
+            }
+            case EventFieldDeclarationSyntax ef:
+            {
+                foreach (var v in ef.Declaration.Variables)
+                {
+                    var sym = sm.GetDeclaredSymbol(v);
+                    if (sym is not null) into.Add(ToCodeSymbol(sym));
+                }
+                return;
+            }
+        }
+    }
+
+    public async Task<LocationListResult> CodeGotoDefinitionAsync(CodePosition position, CancellationToken cancellationToken = default)
+    {
+        if (position is null) throw new VsmcpException(ErrorCodes.NotFound, "position is required.");
+        var ws = await GetWorkspaceAsync(cancellationToken);
+        var doc = FindDocument(ws.CurrentSolution, position.File)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"File not part of any loaded project: {position.File}");
+
+        var text = await doc.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var pos = PositionFromLineCol(text, position.Line, position.Column);
+        var symbol = await SymbolFinder.FindSymbolAtPositionAsync(doc, pos, cancellationToken).ConfigureAwait(false);
+        var result = new LocationListResult();
+        if (symbol is null) return result;
+        result.Symbol = ToCodeSymbol(symbol);
+        foreach (var loc in symbol.Locations)
+            if (loc.IsInSource) result.Locations.Add(SpanFromLocation(loc));
+        return result;
+    }
+
+    public async Task<ReferencesResult> CodeFindReferencesAsync(CodePosition position, int maxResults, CancellationToken cancellationToken = default)
+    {
+        if (position is null) throw new VsmcpException(ErrorCodes.NotFound, "position is required.");
+        if (maxResults <= 0) maxResults = 500;
+        if (maxResults > 5000) maxResults = 5000;
+
+        var ws = await GetWorkspaceAsync(cancellationToken);
+        var doc = FindDocument(ws.CurrentSolution, position.File)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"File not part of any loaded project: {position.File}");
+
+        var text = await doc.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var pos = PositionFromLineCol(text, position.Line, position.Column);
+        var symbol = await SymbolFinder.FindSymbolAtPositionAsync(doc, pos, cancellationToken).ConfigureAwait(false);
+        var result = new ReferencesResult();
+        if (symbol is null) return result;
+        result.Symbol = ToCodeSymbol(symbol);
+
+        foreach (var loc in symbol.Locations)
+            if (loc.IsInSource) result.Definitions.Add(SpanFromLocation(loc));
+
+        var refs = await SymbolFinder.FindReferencesAsync(symbol, ws.CurrentSolution, cancellationToken).ConfigureAwait(false);
+        int total = 0;
+        foreach (var group in refs)
+        {
+            foreach (var rl in group.Locations)
+            {
+                total++;
+                if (result.References.Count < maxResults)
+                    result.References.Add(SpanFromLocation(rl.Location));
+            }
+        }
+        result.TotalReferences = total;
+        result.Truncated = total > result.References.Count;
+        return result;
+    }
+
+    public async Task<DiagnosticsResult> CodeDiagnosticsAsync(string? file, int maxResults, CancellationToken cancellationToken = default)
+    {
+        if (maxResults <= 0) maxResults = 500;
+        if (maxResults > 10_000) maxResults = 10_000;
+
+        var ws = await GetWorkspaceAsync(cancellationToken);
+        var solution = ws.CurrentSolution;
+        var result = new DiagnosticsResult();
+        int total = 0;
+
+        if (!string.IsNullOrWhiteSpace(file))
+        {
+            var doc = FindDocument(solution, file!)
+                ?? throw new VsmcpException(ErrorCodes.NotFound, $"File not part of any loaded project: {file}");
+            result.FilesScanned.Add(doc.FilePath ?? file!);
+            var sm = await doc.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (sm is not null)
+            {
+                foreach (var d in sm.GetDiagnostics(cancellationToken: cancellationToken))
+                {
+                    total++;
+                    if (result.Diagnostics.Count < maxResults)
+                        result.Diagnostics.Add(ToDiagInfo(d));
+                }
+            }
+        }
+        else
+        {
+            foreach (var project in solution.Projects)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                if (compilation is null) continue;
+                foreach (var tree in compilation.SyntaxTrees)
+                {
+                    if (!string.IsNullOrEmpty(tree.FilePath)) result.FilesScanned.Add(tree.FilePath);
+                }
+                foreach (var d in compilation.GetDiagnostics(cancellationToken))
+                {
+                    total++;
+                    if (result.Diagnostics.Count < maxResults)
+                        result.Diagnostics.Add(ToDiagInfo(d));
+                }
+            }
+        }
+
+        result.TotalDiagnostics = total;
+        result.Truncated = total > result.Diagnostics.Count;
+        return result;
+    }
+
+    private static CodeDiagnosticInfo ToDiagInfo(Diagnostic d) => new()
+    {
+        Id = d.Id,
+        Severity = d.Severity switch
+        {
+            DiagnosticSeverity.Error => CodeDiagnosticSeverity.Error,
+            DiagnosticSeverity.Warning => CodeDiagnosticSeverity.Warning,
+            DiagnosticSeverity.Info => CodeDiagnosticSeverity.Info,
+            _ => CodeDiagnosticSeverity.Hidden,
+        },
+        Message = d.GetMessage(),
+        Category = d.Descriptor.Category,
+        Location = d.Location != Location.None ? SpanFromLocation(d.Location) : null,
+    };
+
+    public async Task<QuickInfoResult> CodeQuickInfoAsync(CodePosition position, CancellationToken cancellationToken = default)
+    {
+        if (position is null) throw new VsmcpException(ErrorCodes.NotFound, "position is required.");
+        var ws = await GetWorkspaceAsync(cancellationToken);
+        var doc = FindDocument(ws.CurrentSolution, position.File)
+            ?? throw new VsmcpException(ErrorCodes.NotFound, $"File not part of any loaded project: {position.File}");
+
+        var text = await doc.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var pos = PositionFromLineCol(text, position.Line, position.Column);
+        var symbol = await SymbolFinder.FindSymbolAtPositionAsync(doc, pos, cancellationToken).ConfigureAwait(false);
+        var result = new QuickInfoResult();
+        if (symbol is null) return result;
+
+        result.Symbol = ToCodeSymbol(symbol);
+        result.Signature = symbol.ToDisplayString();
+        result.Kind = symbol.Kind.ToString();
+        var xml = symbol.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: cancellationToken);
+        if (!string.IsNullOrWhiteSpace(xml)) result.Documentation = xml;
+        return result;
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -73,6 +73,7 @@
     <Compile Include="RpcTarget.Memory.cs" />
     <Compile Include="RpcTarget.Dump.cs" />
     <Compile Include="RpcTarget.Diagnostics.cs" />
+    <Compile Include="RpcTarget.Code.cs" />
     <Compile Include="ModuleTracker.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />
@@ -88,6 +89,8 @@
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.9.37000" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.9.3365" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" PrivateAssets="all" />
     <PackageReference Include="StreamJsonRpc" Version="2.19.27" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="4.9.2" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.9.2" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Adds `code.symbols`, `code.goto_definition`, `code.find_references`, `code.diagnostics`, `code.quick_info` MCP tools backed by `VisualStudioWorkspace` + Roslyn.
- Diagnostics use the per-file semantic model (or per-project `Compilation`) so they do not require an MSBuild build.
- References walk the whole `Solution` via `SymbolFinder.FindReferencesAsync`.

Closes #9.

## Test plan
- [ ] Build in an Experimental VS (`/rootsuffix Exp`); load this repo.
- [ ] `code.symbols` on a source file returns a nested outline (namespaces → types → members).
- [ ] `code.goto_definition` at a symbol identifier returns its declaration span.
- [ ] `code.find_references` returns definition + reference spans; `Truncated=true` when results exceed `maxResults`.
- [ ] `code.diagnostics` with a file returns per-file diagnostics; without a file returns the solution-wide set.
- [ ] `code.quick_info` returns a display-form signature and documentation XML for documented symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)