### PR TITLE
M10: config file, rolling file logging, pack nupkg in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,11 @@ jobs:
         run: |
           msbuild src/VSMCP.sln -t:Restore,Build -p:Configuration=Release -v:minimal -nologo
 
+      - name: Pack VSMCP.Server (dotnet tool)
+        shell: pwsh
+        run: |
+          dotnet pack src/VSMCP.Server/VSMCP.Server.csproj -c Release --no-build -o artifacts -nologo
+
       - name: Upload VSIX
         uses: actions/upload-artifact@v4
         with:
@@ -36,9 +41,16 @@ jobs:
           path: src/VSMCP.Vsix/bin/Release/*.vsix
           if-no-files-found: error
 
-      - name: Upload VSMCP.Server
+      - name: Upload VSMCP.Server (build output)
         uses: actions/upload-artifact@v4
         with:
           name: VSMCP.Server
           path: src/VSMCP.Server/bin/Release/**/*
+          if-no-files-found: error
+
+      - name: Upload VSMCP.Server nupkg
+        uses: actions/upload-artifact@v4
+        with:
+          name: VSMCP.Server.nupkg
+          path: artifacts/*.nupkg
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -79,15 +79,20 @@ Optional file: `%LOCALAPPDATA%\VSMCP\config.json`
 
 ```json
 {
-  "logLevel": "info",
+  "logLevel": "warning",
   "allowSideEffects": false,
   "allowDbgEng": false,
-  "defaultTimeoutMs": 30000
+  "defaultTimeoutMs": 30000,
+  "fileLoggingEnabled": false,
+  "logDirectory": null
 }
 ```
 
+- `logLevel` — `trace | debug | info | warning | error | critical | none`. Default `warning`.
+- `fileLoggingEnabled` — when true, the bridge writes date-rolling log files to `logDirectory` (default `%LOCALAPPDATA%\VSMCP\logs`). Off by default because MCP clients already capture stderr.
 - `allowSideEffects` — gate `eval.expression` and `memory.write`. Off by default.
 - `allowDbgEng` — allow the `dump.dbgeng` DbgEng passthrough (`!analyze -v`, etc.). Off by default.
+- `defaultTimeoutMs` — fallback timeout for RPC calls that don't specify one.
 
 ---
 

--- a/src/VSMCP.Server/Program.cs
+++ b/src/VSMCP.Server/Program.cs
@@ -3,13 +3,22 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using VSMCP.Server;
 
+var config = VsmcpConfig.Load();
 var builder = Host.CreateApplicationBuilder(args);
 
 // MCP uses stdio; logs must not pollute stdout. Route logs to stderr only.
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole(o => o.LogToStandardErrorThreshold = LogLevel.Trace);
-builder.Logging.SetMinimumLevel(LogLevel.Warning);
+builder.Logging.SetMinimumLevel(ParseLogLevel(config.LogLevel));
 
+if (config.FileLoggingEnabled)
+{
+    builder.Logging.AddProvider(new RollingFileLoggerProvider(
+        config.ResolveLogDirectory(),
+        ParseLogLevel(config.LogLevel)));
+}
+
+builder.Services.AddSingleton(config);
 builder.Services.AddSingleton<VsConnection>();
 builder.Services.AddSingleton<ProfilerHost>();
 
@@ -18,4 +27,23 @@ builder.Services
     .WithStdioServerTransport()
     .WithToolsFromAssembly();
 
-await builder.Build().RunAsync();
+var app = builder.Build();
+
+if (config.LoadError is not null)
+    app.Services.GetRequiredService<ILoggerFactory>()
+        .CreateLogger("VSMCP.Server")
+        .LogWarning("{err}", config.LoadError);
+
+await app.RunAsync();
+
+static LogLevel ParseLogLevel(string level) => level?.ToLowerInvariant() switch
+{
+    "trace" => LogLevel.Trace,
+    "debug" => LogLevel.Debug,
+    "info" or "information" => LogLevel.Information,
+    "warn" or "warning" => LogLevel.Warning,
+    "error" => LogLevel.Error,
+    "critical" => LogLevel.Critical,
+    "none" or "off" => LogLevel.None,
+    _ => LogLevel.Warning,
+};

--- a/src/VSMCP.Server/RollingFileLoggerProvider.cs
+++ b/src/VSMCP.Server/RollingFileLoggerProvider.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// Minimal date-rolling file logger. Writes one file per day under the configured directory
+/// with name <c>server-YYYYMMDD.log</c>. Opt-in; kept dependency-free so we don't pull Serilog
+/// into a tool package.
+/// </summary>
+public sealed class RollingFileLoggerProvider : ILoggerProvider
+{
+    private readonly string _directory;
+    private readonly LogLevel _minLevel;
+    private readonly object _writeLock = new();
+    private readonly ConcurrentDictionary<string, RollingFileLogger> _loggers = new();
+
+    public RollingFileLoggerProvider(string directory, LogLevel minLevel)
+    {
+        _directory = directory;
+        _minLevel = minLevel;
+        Directory.CreateDirectory(_directory);
+    }
+
+    public ILogger CreateLogger(string categoryName) =>
+        _loggers.GetOrAdd(categoryName, name => new RollingFileLogger(name, this));
+
+    internal void Write(string category, LogLevel level, string message, Exception? ex)
+    {
+        if (level < _minLevel) return;
+        var path = Path.Combine(_directory, $"server-{DateTime.UtcNow:yyyyMMdd}.log");
+        var sb = new StringBuilder(256);
+        sb.Append(DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture));
+        sb.Append(' ').Append(LevelTag(level));
+        sb.Append(' ').Append(category);
+        sb.Append(' ').Append(message);
+        if (ex is not null) sb.Append(' ').Append(ex);
+        sb.Append('\n');
+
+        lock (_writeLock)
+        {
+            try { File.AppendAllText(path, sb.ToString()); }
+            catch { /* file locked / disk full — don't crash the bridge */ }
+        }
+    }
+
+    public void Dispose() => _loggers.Clear();
+
+    private static string LevelTag(LogLevel l) => l switch
+    {
+        LogLevel.Trace => "TRC",
+        LogLevel.Debug => "DBG",
+        LogLevel.Information => "INF",
+        LogLevel.Warning => "WRN",
+        LogLevel.Error => "ERR",
+        LogLevel.Critical => "CRT",
+        _ => "NUL",
+    };
+
+    private sealed class RollingFileLogger : ILogger
+    {
+        private readonly string _category;
+        private readonly RollingFileLoggerProvider _owner;
+
+        public RollingFileLogger(string category, RollingFileLoggerProvider owner)
+        {
+            _category = category;
+            _owner = owner;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= _owner._minLevel;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (!IsEnabled(logLevel)) return;
+            var msg = formatter(state, exception);
+            if (string.IsNullOrEmpty(msg) && exception is null) return;
+            _owner.Write(_category, logLevel, msg, exception);
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}

--- a/src/VSMCP.Server/VSMCP.Server.csproj
+++ b/src/VSMCP.Server/VSMCP.Server.csproj
@@ -7,9 +7,19 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>vsmcp-server</ToolCommandName>
     <PackageId>VSMCP.Server</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>Paul Iver</Authors>
     <Description>Model Context Protocol server that drives Visual Studio 2022. Pairs with the VSMCP VSIX extension.</Description>
     <PackageTags>mcp;visual-studio;debugger;claude;ai</PackageTags>
+    <PackageProjectUrl>https://github.com/pauliver/VSMCP</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/pauliver/VSMCP</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />

--- a/src/VSMCP.Server/VsmcpConfig.cs
+++ b/src/VSMCP.Server/VsmcpConfig.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// Bridge-side configuration, loaded lazily from <c>%LOCALAPPDATA%\VSMCP\config.json</c>.
+/// Missing fields fall back to defaults. The file is optional.
+/// </summary>
+public sealed class VsmcpConfig
+{
+    public string LogLevel { get; set; } = "warning";
+    public bool AllowSideEffects { get; set; } = false;
+    public bool AllowDbgEng { get; set; } = false;
+    public int DefaultTimeoutMs { get; set; } = 30_000;
+    public bool FileLoggingEnabled { get; set; } = false;
+
+    /// <summary>Override the log directory. Default: <c>%LOCALAPPDATA%\VSMCP\logs</c>.</summary>
+    public string? LogDirectory { get; set; }
+
+    [JsonIgnore] public string? LoadedFromPath { get; set; }
+    [JsonIgnore] public string? LoadError { get; set; }
+
+    public static string DefaultRootDir =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "VSMCP");
+
+    public static string DefaultConfigPath => Path.Combine(DefaultRootDir, "config.json");
+
+    public string ResolveLogDirectory() =>
+        string.IsNullOrWhiteSpace(LogDirectory)
+            ? Path.Combine(DefaultRootDir, "logs")
+            : Path.GetFullPath(LogDirectory!);
+
+    public static VsmcpConfig Load() => Load(DefaultConfigPath);
+
+    public static VsmcpConfig Load(string path)
+    {
+        var config = new VsmcpConfig();
+        if (!File.Exists(path)) return config;
+
+        try
+        {
+            var json = File.ReadAllText(path);
+            var parsed = JsonSerializer.Deserialize<VsmcpConfig>(json, JsonOptions);
+            if (parsed is not null)
+            {
+                config = parsed;
+                config.LoadedFromPath = path;
+            }
+        }
+        catch (Exception ex)
+        {
+            config.LoadError = $"Failed to parse {path}: {ex.Message}";
+        }
+        return config;
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+}


### PR DESCRIPTION
## Summary
- Parse `%LOCALAPPDATA%\VSMCP\config.json` at bridge startup; all fields optional (see README for schema).
- Add an opt-in, dependency-free date-rolling file logger to `%LOCALAPPDATA%\VSMCP\logs\server-YYYYMMDD.log`.
- Fill in NuGet metadata on `VSMCP.Server` so `dotnet pack` emits a publishable .nupkg.
- CI: pack the tool and upload the .nupkg as a build artifact next to the VSIX.

Partially closes #10 (packaging/DX). Marketplace + NuGet publishing and code-signing are intentionally deferred — they need org-level secrets/accounts and should be their own follow-up tickets; #10 stays open for that scope.

## Test plan
- [ ] `dotnet build src/VSMCP.Server` — 0 errors.
- [ ] `dotnet pack src/VSMCP.Server -c Release` produces `VSMCP.Server.0.1.0.nupkg`.
- [ ] Bridge starts without a config file (all defaults).
- [ ] With `{ \"fileLoggingEnabled\": true, \"logLevel\": \"debug\" }`, log file appears under `%LOCALAPPDATA%\VSMCP\logs` and rolls by date.
- [ ] Malformed config — bridge starts anyway and emits a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)