### PR TITLE
M11: Claude Skills for VSMCP workflows

### DIFF
--- a/skills/Build.md
+++ b/skills/Build.md
@@ -1,0 +1,27 @@
+---
+name: Build
+description: Build (or rebuild, clean) the VS solution through VSMCP and diagnose compile/link errors. Use when the user says "build", "compile", "why won't this build", "fix the errors", or asks to clean/rebuild. Not for runtime debugging — use Debug once the binaries exist.
+---
+
+# Build playbook
+
+## 1. Pick the scope
+- Whole solution (default): `build.start()`.
+- Specific projects: `build.start({projectIds:[...]})` — resolve names via `project.list()` first if the user used informal names.
+- Rebuild (clean + build): `build.rebuild(...)`. Clean only: `build.clean(...)`.
+- Respect any `configuration` / `platform` override the user mentioned ("debug", "release", "x64").
+
+## 2. Wait
+`build.wait({buildId, timeoutMs: 600000})`. If `TimedOut`, report progress via `build.status` and ask whether to keep waiting or cancel with `build.cancel`.
+
+## 3. Triage on failure
+If `Status=Failed`:
+1. `build.errors({buildId})` — primary signal. Group by project/file, pick the first N unique diagnostics.
+2. `build.warnings({buildId})` — only if errors empty or user asked.
+3. If the errors look like configuration drift rather than real compile failures (missing SDK, bad target framework), `build.output({buildId})` for the raw MSBuild log.
+
+## 4. Faster loop for iterative fixes
+For "keep rebuilding until it's green", prefer `code.diagnostics({file?})` between edits — it runs Roslyn without invoking MSBuild, so it catches 90% of C#/VB errors in milliseconds. Fall back to `build.start` when native/SDK/linker errors are suspected or after major project-file edits.
+
+## 5. Hand back
+Report: Succeeded/Failed, elapsed, count of errors+warnings, and the top 3 error messages with `file:line`. If you fixed errors via edits (through the Project skill), say which.

--- a/skills/Debug.md
+++ b/skills/Debug.md
@@ -1,0 +1,32 @@
+---
+name: Debug
+description: Drive a live debug session in Visual Studio through VSMCP — launch or attach, set breakpoints, step, inspect threads/stacks/locals, evaluate expressions. Use when the user wants to reproduce a bug, step through code, stop at a line, check a variable's value at runtime, or understand what a process is doing right now. Not for crash dumps (use DebugCrash), not for performance (use DebugPerf), not for native-only workflows (use DebugNative).
+---
+
+# Debug playbook
+
+## 1. Start or attach
+- "run / launch the app" → `debug.launch({projectId?, args?, env?, cwd?, noDebug?})`. Omit `projectId` to use the configured startup project.
+- "attach to X" → `processes.list({nameContains:"X"})` then `debug.attach({pid})`. Prefer `pid` over `processName` if both are known.
+- After either call, poll `debug.state()` until `Debugging=true` and `Mode` settles (Run or Break).
+
+## 2. Set breakpoints before the code runs
+`bp.set({kind:"Line", file, line, conditionExpression?, tracepointMessage?})`. For "log this value" use a tracepoint via `bp.set_tracepoint`; don't add `Console.WriteLine` edits. `bp.list()` to confirm.
+
+## 3. Break mode — inspect
+When `Mode=Break`:
+- `threads.list()` → pick the stopped thread. `threads.switch({threadId})` if needed.
+- `stack.get({depth:32})`.
+- `frame.locals({expandDepth:1})` on the top frame. Drop to `frame.arguments` if locals look empty.
+- Expression values: `eval.expression({options:{expression, frameIndex?, allowSideEffects:false}})`. Flip `allowSideEffects=true` only after the user confirms they want to run code.
+
+## 4. Step
+`debug.step_into` (into calls) / `debug.step_over` (treat calls atomic) / `debug.step_out` (run to caller). `debug.run_to_cursor({file, line})` skips the boring middle. `debug.continue` resumes until next break/exception.
+
+## 5. Destructive / unusual ops — confirm first
+- `debug.set_next_statement` — can skip constructors; confirm and pass `allowSideEffects:true`.
+- `threads.freeze` / `threads.thaw` — useful for race repros; undo before continuing.
+
+## 6. Finish
+- "stop" → `debug.stop`. "leave it running" → `debug.detach`.
+- Report: what broke where, the value that was wrong, and which source span you'd change.

--- a/skills/DebugCrash.md
+++ b/skills/DebugCrash.md
@@ -1,0 +1,33 @@
+---
+name: DebugCrash
+description: Analyze a Windows crash dump (.dmp / minidump / full dump) of a .NET or native process through VSMCP. Use when the user provides a dump path, says "why did it crash", mentions "access violation" / "unhandled exception" in post-mortem, or asks to capture a dump of a running process. Not for live debugging (use Debug), not for profiling (use DebugPerf).
+---
+
+# DebugCrash playbook
+
+## 1. Get the dump
+- User has a `.dmp` → go to §2.
+- User wants to capture from a live PID → `dump.save({pid, path, full:true})`. `full:true` for root-cause analysis; `full:false` if disk space / privacy matters.
+
+## 2. Open it
+`dump.open({path})`. VS enters a dump debug session; the rest of this playbook uses the normal debug tools against that session.
+
+## 3. Summarize
+`dump.summary()`. Expected fields: `FaultingThreadId`, `ExceptionMessage`, process id/name, module counts (managed vs native). If `FaultingThreadId` is null and there's no exception, it's likely a hang/cancel dump — report that and ask for a full dump captured during the actual fault.
+
+## 4. Walk the faulting thread
+1. `threads.switch({threadId: faultingTid})`.
+2. `stack.get({depth:32})`.
+3. For the top 3–8 frames: `frame.locals({frameIndex, expandDepth:1})`. Stop early if an obvious bad value shows up (null, `-1`, wrong handle, corrupted pointer).
+4. If frames show `???` or wrong offsets, call `modules.list` → `symbols.status` on the faulting module. Ask the user for a symbol path if stripped.
+
+## 5. Native / unresolved
+If the faulting frame is native and stack doesn't resolve:
+- Try `dump.dbgeng({command:"!analyze -v"})` — requires `allowDbgEng:true` in `%LOCALAPPDATA%\VSMCP\config.json`. If disabled, ask the user to enable it before continuing.
+- Fallback: switch to DebugNative for disasm / memory / register inspection of the frame.
+
+## 6. Managed exceptions
+If `ExceptionMessage` is non-empty, don't stop at it — that's the symptom. Walk back 3–5 frames to find the caller that passed bad state in.
+
+## 7. Hand back
+Three sentences max: what threw, where the bad state came from (`file:line`), and the smallest code change that would prevent it. Propose the edit only if asked (then switch to Project/Build).

--- a/skills/DebugMemory.md
+++ b/skills/DebugMemory.md
@@ -1,0 +1,28 @@
+---
+name: DebugMemory
+description: Investigate memory behavior in a running .NET process through VSMCP — leaks, high working set, GC pressure, allocation hot paths. Use when the user says "leak", "OOM", "high RAM", "GC pressure", "allocating too much", or asks what's allocating. Not for CPU time (use DebugPerf), not for post-mortem (use DebugCrash).
+---
+
+# DebugMemory playbook
+
+## 1. Frame the question
+- "Is it growing?" → longitudinal counters (§2).
+- "What's allocating?" → allocation profile (§3).
+- "What's still alive?" → inspection via live debug (§4).
+
+## 2. Longitudinal counters
+`counters.get({pid, sampleMs:500})` at t0, then again at t=30s, 60s. Compare `WorkingSetBytes`, `PrivateMemoryBytes`. A steady climb is the leak signal; a flat-but-large value is usually just warm caches.
+
+## 3. Allocation profile
+`profiler.start({pid, mode:"Allocations"})` → drive the suspect workload → `profiler.stop` → `profiler.report({path, top:30})`. The hot "functions" in an allocation trace are the *allocating* frames, not CPU hot paths. Look for: high-frequency small allocs on a tight loop, surprising `string.Concat` / boxing, or large arrays created per request.
+
+## 4. Live inspection when you need object identity
+Only if steps 2–3 don't localize it:
+1. Attach: `debug.attach({pid})`.
+2. `debug.break_all`.
+3. `eval.expression({options:{expression:"System.GC.GetTotalMemory(false)"}})` — with `allowSideEffects:false` unless the user accepts that `GC.Collect`-style probes run code.
+4. Ask the user to point at the suspect type; use `eval` to count instances (`AppDomain`-style queries require side-effects).
+5. `debug.detach` when done — don't `stop`, we don't want to kill the process.
+
+## 5. Hand back
+Say one of: (a) not actually a leak — memory is bounded and settles; (b) leak localized to allocator `X` at `file:line` in type `Y`; (c) inconclusive — request a longer reproduction or a .dmp for offline inspection (switch to DebugCrash).

--- a/skills/DebugNative.md
+++ b/skills/DebugNative.md
@@ -1,0 +1,35 @@
+---
+name: DebugNative
+description: Debug the unmanaged / C++ side of a process through VSMCP — inspect memory, CPU registers, and disassembly; attach with the native engine; handle mixed-mode scenarios. Use when the user says "unmanaged", "C++", "native heap", "access violation at 0x…", "disassembly", "registers", or is debugging a P/Invoke boundary. Not for pure managed frames (use Debug), not for post-mortem (use DebugCrash, which can fall back here).
+---
+
+# DebugNative playbook
+
+## 1. Attach with the native engine
+`debug.attach({pid, engines:["Native"]})` (or `["Managed (.NET Core)","Native"]` for mixed-mode). Omit `engines` only when VS's auto-pick has already DTRT in this session.
+
+## 2. Reach the faulting frame
+If already broken, `debug.state()`. Otherwise `debug.break_all`, then `threads.list` → `threads.switch` to the interesting thread. `stack.get({depth:32})`.
+
+## 3. Walk the native frame
+For the frame of interest:
+- `frame.switch({frameIndex})`.
+- `registers.get()` — full group tree (CPU, CPU Segments, Floating Point, SSE). Read RIP/RSP/RBP and the first-4-args calling-convention registers (RCX/RDX/R8/R9 on x64 Windows).
+- `disasm.get({address:rip, count:64})` — includes symbol names + source mapping when PDBs are available.
+
+## 4. Memory probes
+- Read: `memory.read({address, length})`. Cap at 64 KiB — for larger ranges, call repeatedly.
+- Write: `memory.write({address, hex, allowSideEffects:true})`. **Always** confirm with the user first; writing into a running process corrupts state.
+- If the address came from a register or a pointer deref, sanity-check it's inside a loaded module by cross-referencing `modules.list` base+size.
+
+## 5. Symbols
+- `modules.list` → find the faulting module → `symbols.status({moduleId})`. If `Loaded=false`, `symbols.load({moduleId})` and ask the user for a `.pdb` path / symbol server if that fails.
+- A stripped module means disasm without source. Prefer `disasm.get` over guessing; use `dump.dbgeng({command:"!analyze -v"})` (requires `allowDbgEng`) for broader heuristics.
+
+## 6. Common patterns
+- **Access violation**: check the faulting address in `registers.get` then `memory.read` near it — pattern-match for `0x00000000` (null), `0xCCCCCCCC` (uninit stack), `0xDDDDDDDD` / `0xFEEEFEEE` (freed heap).
+- **P/Invoke boundary**: walk the stack until you cross from managed → native; compare argument registers at the boundary against the P/Invoke signature in source.
+- **Stack corruption**: RBP/RSP that don't match the frame layout, `stack.get` truncating early — suspect buffer overrun; inspect neighbors with `memory.read`.
+
+## 7. Hand back
+State: function + module + offset + likely cause (null deref / use-after-free / UB pattern / ABI mismatch). Suggest the source change only on request.

--- a/skills/DebugPerf.md
+++ b/skills/DebugPerf.md
@@ -1,0 +1,31 @@
+---
+name: DebugPerf
+description: Profile CPU usage of a running .NET process through VSMCP and identify hot functions. Use when the user says "slow", "where is the time going", "profile", "find the hot path", or provides a .nettrace to analyze. Not for memory/allocations (use DebugMemory), not for crashes (use DebugCrash).
+---
+
+# DebugPerf playbook
+
+## 1. Identify the target
+If the user already has a PID, use it. Otherwise: `processes.list({nameContains})` (scoped to the current Windows session by default). Confirm a match before starting a session.
+
+## 2. Baseline
+Optional one-liner before profiling: `counters.get({pid, sampleMs:500})` to record CPU% / working set now — useful for "was it even busy?" calibration.
+
+## 3. Start the session
+`profiler.start({pid, mode:"CpuSampling"})`. Returns a `sessionId` and an `outputPath` (a `.nettrace` being streamed to disk). Target must be .NET 5+ with an open diagnostic port.
+
+## 4. Drive the workload
+Tell the user to reproduce the slow behavior now. Wait the minimum time to capture the hot path — ~10s for CPU-bound loops, ~30s for cold-start measurements. Don't poll the trace during capture.
+
+## 5. Stop and report
+- `profiler.stop({sessionId})` → captures `.nettrace` size and duration.
+- `profiler.report({path:outputPath, top:20})` → leaf-of-stack sample counts by function, with `PercentOfSamples`.
+- Report: duration, total samples, top 5–10 hot functions with percent and module. If `Empty=true`, the trace failed to resolve — check target was still running when `stop` fired and symbols are available.
+
+## 6. When one session isn't enough
+- Symbols missing / obfuscated frames → ensure the target has PDBs on disk and re-run.
+- Work happens in a child process → profile that PID instead.
+- Long tail suggests many small callers → ask to drill by calling `profiler.report` with a larger `top` (capped 1000), then group by module.
+
+## 7. Hand back
+Root cause in 3 sentences max: the hot function, why it's hot (algorithmic / repeated allocation / sync I/O on hot path), and a concrete source location to change. Do not propose edits without the user asking — switch to Build/Project skills when they do.

--- a/skills/Project.md
+++ b/skills/Project.md
@@ -1,0 +1,34 @@
+---
+name: Project
+description: Create, modify, or inspect a .NET project inside the VS solution currently open through VSMCP. Use when the user asks to add/remove a project, add/remove a file, create a folder, read or edit a project property, or open/save a source file through VS's editor (so undo/redo works). Not for building (use Build), not for debugging (use Debug).
+---
+
+# Project playbook
+
+## 1. Confirm a solution is open
+`vs.status()`. If `SolutionOpen=false`, ask the user for a `.sln` path and call `solution.open({path})` before continuing.
+
+## 2. Locate the project
+`project.list()` to resolve the user's target (prefer `UniqueName`, fall back to `Name`, last resort `FullPath`). If the user names a project that doesn't exist and is asking to **add** one, go to §4; otherwise ask them to pick from the list.
+
+## 3. Read intent
+- "show me / what is" → read-only: `project.properties.get`, `file.read`.
+- "create / add" → §4.
+- "remove / delete" → §5 (destructive — confirm with user first).
+- "edit / change" → §6.
+
+## 4. Add
+- New project: `project.add({templateOrProjectPath, destinationPath, projectName})`.
+- Existing file into project: `project.file.add({projectId, path, linkOnly?})`. Default `linkOnly=false` (copies into the project folder).
+- Folder: `project.folder.create({projectId, path})`.
+
+## 5. Remove (destructive — confirm)
+- Project: `project.remove({projectId})` — does not delete files from disk.
+- File: `project.file.remove({projectId, path, deleteFromDisk?})`. Ask before `deleteFromDisk=true`.
+
+## 6. Edit
+- Property: `project.properties.set({projectId, values:{key:value}})`. Null clears.
+- Source file: prefer `file.replace_range({path, range, text})` for targeted edits; `file.write` for full rewrites. If the file is already open in VS, edits route through the text buffer so VS undo works. Call `editor.save({path})` or `editor.save_all()` when done.
+
+## 7. Hand back
+One line: what changed, which project, which file.


### PR DESCRIPTION
## Summary
Seven Claude Skill playbooks under `skills/` that steer AI assistants through VSMCP tools for each user intent. Each skill is a terse, one-job playbook with YAML frontmatter (name + description with trigger/anti-trigger cues) and a Markdown body.

| Skill | Triggers on | Anti-triggers to |
|---|---|---|
| Project.md | add/remove project, file, folder, properties | — |
| Build.md | build, compile, errors | code.diagnostics for at-rest |
| Debug.md | run, attach, step, break, inspect | DebugCrash / DebugPerf / DebugNative |
| DebugPerf.md | slow, hot path, profile, .nettrace | DebugMemory, DebugCrash |
| DebugMemory.md | leak, OOM, GC pressure, allocations | DebugPerf, DebugCrash |
| DebugCrash.md | .dmp, post-mortem, "why did it crash" | Debug, DebugPerf |
| DebugNative.md | unmanaged, C++, registers, disasm, P/Invoke | Debug (managed), DebugCrash |

Playbooks follow DesignDoc §10.3 rules: one job, no tool invention, read-only by default with explicit confirm for side-effect ops, and a "hand back" step that reports root cause not patches (defer to Project/Build for edits).

## Test plan
- [ ] Skills load in Claude Code when placed under a project's `skills/` directory
- [ ] Trigger phrases dispatch to the correct playbook (smoke test each)
- [ ] Destructive ops (memory.write, set_next_statement, threads.freeze, solution close, project remove) only run after user confirmation per playbook
- [ ] Fixture e2e tests (HelloCrash / HotLoop / NativeConsole) — deferred, tracked separately

Closes #11.