### PR TITLE
M8 (tail): counters.subscribe + trace.start/stop/report

### DIFF
--- a/src/VSMCP.Server/CountersSubscriptionHost.cs
+++ b/src/VSMCP.Server/CountersSubscriptionHost.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using VSMCP.Shared;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// Background poller that samples per-process counters at a fixed cadence and buffers the results
+/// for out-of-band retrieval via <see cref="Read"/>. Subscriptions self-terminate when the target
+/// process exits.
+/// </summary>
+public sealed class CountersSubscriptionHost : IDisposable
+{
+    private const int DefaultBufferSize = 256;
+
+    private readonly ConcurrentDictionary<string, Subscription> _subs = new(StringComparer.Ordinal);
+
+    public CountersSubscriptionHandle Subscribe(int pid, int sampleMs)
+    {
+        if (pid <= 0) throw new ArgumentOutOfRangeException(nameof(pid), "Pid must be > 0.");
+        if (sampleMs < 100) sampleMs = 100;
+        if (sampleMs > 60_000) sampleMs = 60_000;
+
+        Process process;
+        try { process = Process.GetProcessById(pid); }
+        catch (ArgumentException) { throw new InvalidOperationException($"No process with pid {pid}."); }
+
+        var id = Guid.NewGuid().ToString("N");
+        var started = DateTimeOffset.UtcNow;
+        var sub = new Subscription(id, pid, process.ProcessName, sampleMs, DefaultBufferSize, started, process);
+        _subs[id] = sub;
+
+        sub.Task = Task.Run(() => PollLoop(sub, sub.CancelTokenSource.Token));
+
+        return new CountersSubscriptionHandle
+        {
+            SubscriptionId = id,
+            Pid = pid,
+            ProcessName = sub.ProcessName,
+            SampleMs = sampleMs,
+            BufferSize = DefaultBufferSize,
+            StartedUtc = started.ToString("o"),
+        };
+    }
+
+    public CountersReadResult Read(string subscriptionId, int maxSamples)
+    {
+        if (!_subs.TryGetValue(subscriptionId, out var sub))
+            throw new InvalidOperationException($"No counters subscription '{subscriptionId}'.");
+        if (maxSamples <= 0) maxSamples = DefaultBufferSize;
+        if (maxSamples > DefaultBufferSize) maxSamples = DefaultBufferSize;
+
+        var result = new CountersReadResult { SubscriptionId = subscriptionId };
+        lock (sub.BufferLock)
+        {
+            while (result.Samples.Count < maxSamples && sub.Buffer.TryDequeue(out var s))
+                result.Samples.Add(s);
+            result.Dropped = Interlocked.Read(ref sub.Dropped);
+        }
+        result.Ended = sub.Ended;
+        result.EndReason = sub.EndReason;
+        return result;
+    }
+
+    public CountersUnsubscribeResult Unsubscribe(string subscriptionId)
+    {
+        if (!_subs.TryRemove(subscriptionId, out var sub))
+            throw new InvalidOperationException($"No counters subscription '{subscriptionId}'.");
+
+        sub.CancelTokenSource.Cancel();
+        try { sub.Task?.Wait(TimeSpan.FromSeconds(3)); } catch { }
+        sub.CancelTokenSource.Dispose();
+        try { sub.Process.Dispose(); } catch { }
+
+        return new CountersUnsubscribeResult
+        {
+            SubscriptionId = subscriptionId,
+            TotalSamples = Interlocked.Read(ref sub.TotalSamples),
+            Dropped = Interlocked.Read(ref sub.Dropped),
+            DurationSeconds = (DateTimeOffset.UtcNow - sub.StartedUtc).TotalSeconds,
+        };
+    }
+
+    public IReadOnlyList<string> ActiveSubscriptionIds()
+    {
+        var keys = new List<string>(_subs.Keys);
+        keys.Sort(StringComparer.Ordinal);
+        return keys;
+    }
+
+    public void Dispose()
+    {
+        foreach (var kv in _subs)
+        {
+            try { kv.Value.CancelTokenSource.Cancel(); } catch { }
+            try { kv.Value.Process.Dispose(); } catch { }
+        }
+        _subs.Clear();
+    }
+
+    private static async Task PollLoop(Subscription sub, CancellationToken ct)
+    {
+        var process = sub.Process;
+        var logicalCpus = Environment.ProcessorCount;
+        try
+        {
+            TimeSpan prev;
+            try { prev = process.TotalProcessorTime; }
+            catch (Exception ex) { sub.Ended = true; sub.EndReason = "access_denied: " + ex.Message; return; }
+            var prevT = DateTime.UtcNow;
+
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(sub.SampleMs, ct).ConfigureAwait(false);
+                if (process.HasExited) { sub.Ended = true; sub.EndReason = "process_exit"; return; }
+
+                process.Refresh();
+                TimeSpan now;
+                try { now = process.TotalProcessorTime; }
+                catch (Exception ex) { sub.Ended = true; sub.EndReason = "error: " + ex.Message; return; }
+                var nowT = DateTime.UtcNow;
+
+                var wallMs = (nowT - prevT).TotalMilliseconds;
+                var cpuMsDelta = (now - prev).TotalMilliseconds;
+                var perCore = wallMs > 0 ? (cpuMsDelta / wallMs) * 100.0 : 0.0;
+                var normalized = logicalCpus > 0 ? perCore / logicalCpus : perCore;
+
+                var snap = new CountersSnapshot
+                {
+                    Pid = sub.Pid,
+                    Name = sub.ProcessName,
+                    SampleMs = sub.SampleMs,
+                    CpuPercent = perCore,
+                    CpuPercentNormalized = normalized,
+                    LogicalProcessorCount = logicalCpus,
+                    TotalCpuTimeMs = (long)now.TotalMilliseconds,
+                };
+                try { snap.WorkingSetBytes = process.WorkingSet64; } catch { }
+                try { snap.PrivateMemoryBytes = process.PrivateMemorySize64; } catch { }
+                try { snap.VirtualMemoryBytes = process.VirtualMemorySize64; } catch { }
+                try { snap.PagedMemoryBytes = process.PagedMemorySize64; } catch { }
+                try { snap.ThreadCount = process.Threads.Count; } catch { }
+                try { snap.HandleCount = process.HandleCount; } catch { }
+                try { snap.UptimeMs = (long)(DateTime.Now - process.StartTime).TotalMilliseconds; } catch { }
+
+                Enqueue(sub, snap);
+                prev = now;
+                prevT = nowT;
+            }
+            sub.Ended = true;
+            sub.EndReason ??= "canceled";
+        }
+        catch (OperationCanceledException)
+        {
+            sub.Ended = true;
+            sub.EndReason ??= "canceled";
+        }
+        catch (Exception ex)
+        {
+            sub.Ended = true;
+            sub.EndReason = "error: " + ex.Message;
+        }
+    }
+
+    private static void Enqueue(Subscription sub, CountersSnapshot snap)
+    {
+        lock (sub.BufferLock)
+        {
+            sub.Buffer.Enqueue(snap);
+            Interlocked.Increment(ref sub.TotalSamples);
+            while (sub.Buffer.Count > sub.BufferSize)
+            {
+                sub.Buffer.TryDequeue(out _);
+                Interlocked.Increment(ref sub.Dropped);
+            }
+        }
+    }
+
+    private sealed class Subscription
+    {
+        public string Id { get; }
+        public int Pid { get; }
+        public string ProcessName { get; }
+        public int SampleMs { get; }
+        public int BufferSize { get; }
+        public DateTimeOffset StartedUtc { get; }
+        public Queue<CountersSnapshot> Buffer { get; } = new();
+        public object BufferLock { get; } = new();
+        public long TotalSamples;
+        public long Dropped;
+        public CancellationTokenSource CancelTokenSource { get; } = new();
+        public Task? Task;
+        public volatile bool Ended;
+        public string? EndReason;
+        public Process Process { get; }
+
+        public Subscription(string id, int pid, string name, int sampleMs, int bufferSize, DateTimeOffset started, Process process)
+        {
+            Id = id;
+            Pid = pid;
+            ProcessName = name;
+            SampleMs = sampleMs;
+            BufferSize = bufferSize;
+            StartedUtc = started;
+            Process = process;
+        }
+    }
+}

--- a/src/VSMCP.Server/Program.cs
+++ b/src/VSMCP.Server/Program.cs
@@ -21,6 +21,8 @@ if (config.FileLoggingEnabled)
 builder.Services.AddSingleton(config);
 builder.Services.AddSingleton<VsConnection>();
 builder.Services.AddSingleton<ProfilerHost>();
+builder.Services.AddSingleton<CountersSubscriptionHost>();
+builder.Services.AddSingleton<TraceHost>();
 
 builder.Services
     .AddMcpServer()

--- a/src/VSMCP.Server/TraceHost.cs
+++ b/src/VSMCP.Server/TraceHost.cs
@@ -1,0 +1,226 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Security.Principal;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Diagnostics.Tracing.Session;
+using VSMCP.Shared;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// Owns active ETW trace sessions (TraceEventSession). Each session streams a .etl to disk until stopped.
+/// Requires admin privileges — ETW user-mode sessions need SeSystemProfilePrivilege or Administrator.
+/// </summary>
+public sealed class TraceHost : IDisposable
+{
+    private readonly ConcurrentDictionary<string, ActiveTrace> _sessions = new(StringComparer.Ordinal);
+
+    public TraceStartResult Start(TraceStartOptions options)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        EnsureAdmin();
+
+        var outPath = string.IsNullOrWhiteSpace(options.OutputPath)
+            ? Path.Combine(Path.GetTempPath(), $"vsmcp-trace-{DateTime.UtcNow:yyyyMMdd-HHmmss}.etl")
+            : Path.GetFullPath(options.OutputPath!);
+        var parent = Path.GetDirectoryName(outPath);
+        if (!string.IsNullOrEmpty(parent) && !Directory.Exists(parent))
+            throw new DirectoryNotFoundException($"Parent directory does not exist: {parent}");
+
+        var sessionName = "VSMCP-Trace-" + Guid.NewGuid().ToString("N").Substring(0, 12);
+        TraceEventSession session;
+        try
+        {
+            session = new TraceEventSession(sessionName, outPath);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to create ETW session: {ex.Message}", ex);
+        }
+
+        if (options.BufferSizeMB is int mb && mb > 0)
+            session.BufferSizeMB = mb;
+
+        var enabled = new List<string>();
+        bool kernelEnabled = false;
+
+        try
+        {
+            if (options.KernelKeywords is { Count: > 0 })
+            {
+                var kw = ParseKernelKeywords(options.KernelKeywords);
+                try
+                {
+                    session.EnableKernelProvider(kw);
+                    kernelEnabled = true;
+                    enabled.Add("KernelTrace:" + kw);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        $"EnableKernelProvider failed (requires admin + Windows 8+ for user-kernel merge): {ex.Message}", ex);
+                }
+            }
+
+            foreach (var p in options.Providers)
+            {
+                if (string.IsNullOrWhiteSpace(p.Name)) continue;
+                var level = p.Level <= 0 ? TraceEventLevel.Informational : (TraceEventLevel)Math.Min(p.Level, 5);
+                var keywords = p.Keywords;
+                if (Guid.TryParse(p.Name.Trim('{', '}'), out var guid))
+                    session.EnableProvider(guid, level, unchecked((ulong)keywords));
+                else
+                    session.EnableProvider(p.Name, level, unchecked((ulong)keywords));
+                enabled.Add(p.Name);
+            }
+        }
+        catch
+        {
+            try { session.Dispose(); } catch { }
+            throw;
+        }
+
+        var id = Guid.NewGuid().ToString("N");
+        var started = DateTimeOffset.UtcNow;
+        _sessions[id] = new ActiveTrace(id, sessionName, outPath, session, started);
+
+        return new TraceStartResult
+        {
+            SessionId = id,
+            OutputPath = outPath,
+            StartedUtc = started.ToString("o"),
+            KernelEnabled = kernelEnabled,
+            ProvidersEnabled = enabled,
+        };
+    }
+
+    public TraceStopResult Stop(string sessionId)
+    {
+        if (!_sessions.TryRemove(sessionId, out var s))
+            throw new InvalidOperationException($"No active trace session '{sessionId}'.");
+
+        try { s.Session.Flush(); } catch { }
+        try { s.Session.Dispose(); } catch { }
+
+        long size = 0;
+        try { size = new FileInfo(s.OutputPath).Length; } catch { }
+        return new TraceStopResult
+        {
+            SessionId = sessionId,
+            OutputPath = s.OutputPath,
+            BytesWritten = size,
+            DurationSeconds = (DateTimeOffset.UtcNow - s.StartedUtc).TotalSeconds,
+        };
+    }
+
+    public TraceReport Report(string etlPath, int top)
+    {
+        if (string.IsNullOrWhiteSpace(etlPath)) throw new ArgumentException("Trace path is required.", nameof(etlPath));
+        etlPath = Path.GetFullPath(etlPath);
+        if (!File.Exists(etlPath)) throw new FileNotFoundException("Trace file not found.", etlPath);
+        if (top <= 0) top = 20;
+        if (top > 1000) top = 1000;
+
+        var report = new TraceReport { Path = etlPath };
+        var byKey = new Dictionary<(string provider, string evt), long>();
+        var byProvider = new Dictionary<string, long>(StringComparer.Ordinal);
+        long total = 0;
+        double durationSec = 0;
+
+        try
+        {
+            using var source = new ETWTraceEventSource(etlPath);
+            DateTime first = DateTime.MinValue, last = DateTime.MinValue;
+            source.AllEvents += ev =>
+            {
+                var provider = string.IsNullOrEmpty(ev.ProviderName) ? ev.ProviderGuid.ToString() : ev.ProviderName;
+                var name = ev.EventName ?? "Unknown";
+                var key = (provider, name);
+                byKey[key] = byKey.TryGetValue(key, out var c) ? c + 1 : 1;
+                byProvider[provider] = byProvider.TryGetValue(provider, out var pc) ? pc + 1 : 1;
+                total++;
+                if (first == DateTime.MinValue) first = ev.TimeStamp;
+                last = ev.TimeStamp;
+            };
+            source.Process();
+            if (first != DateTime.MinValue && last != DateTime.MinValue)
+                durationSec = (last - first).TotalSeconds;
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to read .etl: {ex.Message}", ex);
+        }
+
+        report.TotalEvents = total;
+        report.DurationSeconds = durationSec;
+        report.EventsByProvider = byProvider;
+        if (total == 0) { report.Empty = true; return report; }
+
+        var ordered = new List<KeyValuePair<(string provider, string evt), long>>(byKey);
+        ordered.Sort((a, b) => b.Value.CompareTo(a.Value));
+        for (int i = 0; i < Math.Min(top, ordered.Count); i++)
+        {
+            var e = ordered[i];
+            report.TopEvents.Add(new TraceEventCount
+            {
+                Provider = e.Key.provider,
+                EventName = e.Key.evt,
+                Count = e.Value,
+            });
+        }
+        return report;
+    }
+
+    public IReadOnlyList<string> ActiveSessionIds()
+    {
+        var keys = new List<string>(_sessions.Keys);
+        keys.Sort(StringComparer.Ordinal);
+        return keys;
+    }
+
+    public void Dispose()
+    {
+        foreach (var kv in _sessions)
+        {
+            try { kv.Value.Session.Dispose(); } catch { }
+        }
+        _sessions.Clear();
+    }
+
+    private static KernelTraceEventParser.Keywords ParseKernelKeywords(List<string> names)
+    {
+        KernelTraceEventParser.Keywords combined = KernelTraceEventParser.Keywords.None;
+        foreach (var n in names)
+        {
+            if (string.IsNullOrWhiteSpace(n)) continue;
+            if (!Enum.TryParse<KernelTraceEventParser.Keywords>(n, ignoreCase: true, out var k))
+                throw new ArgumentException($"Unknown kernel keyword '{n}'. See KernelTraceEventParser.Keywords for valid names.");
+            combined |= k;
+        }
+        return combined;
+    }
+
+    private static void EnsureAdmin()
+    {
+        if (!OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("ETW tracing is Windows-only.");
+        using var identity = WindowsIdentity.GetCurrent();
+        var principal = new WindowsPrincipal(identity);
+        if (!principal.IsInRole(WindowsBuiltInRole.Administrator))
+            throw new UnauthorizedAccessException(
+                "trace.start requires Administrator privileges. Re-launch VSMCP.Server elevated or use profiler.start (EventPipe) which does not require admin.");
+    }
+
+    private sealed record ActiveTrace(
+        string SessionId,
+        string WindowsSessionName,
+        string OutputPath,
+        TraceEventSession Session,
+        DateTimeOffset StartedUtc);
+}

--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -17,11 +17,15 @@ public sealed class VsmcpTools
 {
     private readonly VsConnection _connection;
     private readonly ProfilerHost _profiler;
+    private readonly CountersSubscriptionHost _counters;
+    private readonly TraceHost _trace;
 
-    public VsmcpTools(VsConnection connection, ProfilerHost profiler)
+    public VsmcpTools(VsConnection connection, ProfilerHost profiler, CountersSubscriptionHost counters, TraceHost trace)
     {
         _connection = connection;
         _profiler = profiler;
+        _counters = counters;
+        _trace = trace;
     }
 
     [McpServerTool(Name = "ping")]
@@ -841,5 +845,66 @@ public sealed class VsmcpTools
     {
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.CodeQuickInfoAsync(position, ct).ConfigureAwait(false);
+    }
+
+    // -------- Streaming counters (M8) --------
+
+    [McpServerTool(Name = "counters.subscribe")]
+    [Description("Start a background poller that samples process-level counters (CPU%, working set, handle/thread counts, …) at a fixed cadence. Samples are buffered server-side in a ring (up to 256); drain them with counters.read. Stops on process exit or counters.unsubscribe. Unlike counters.get, this does not block the caller for a sample window.")]
+    public Task<CountersSubscriptionHandle> CountersSubscribe(
+        [Description("Target process id.")] int pid,
+        [Description("Sampling interval in milliseconds (100..60000). Default 500ms.")] int sampleMs = 500,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(_counters.Subscribe(pid, sampleMs));
+    }
+
+    [McpServerTool(Name = "counters.read")]
+    [Description("Drain buffered samples from a subscription. Returns up to `maxSamples` snapshots in FIFO order and clears them from the buffer. Reports how many samples were dropped because the ring wrapped and whether the subscription has ended.")]
+    public Task<CountersReadResult> CountersRead(
+        [Description("Subscription id from counters.subscribe.")] string subscriptionId,
+        [Description("Max samples to return (1..256). Default 256.")] int maxSamples = 256,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(_counters.Read(subscriptionId, maxSamples));
+    }
+
+    [McpServerTool(Name = "counters.unsubscribe")]
+    [Description("Stop a counters subscription and free its buffer. Returns the total sample count, dropped count, and duration.")]
+    public Task<CountersUnsubscribeResult> CountersUnsubscribe(
+        [Description("Subscription id from counters.subscribe.")] string subscriptionId,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(_counters.Unsubscribe(subscriptionId));
+    }
+
+    // -------- ETW tracing (M8) --------
+
+    [McpServerTool(Name = "trace.start")]
+    [Description("Start a system-wide ETW trace session. Requires Administrator — user-mode ETW needs SeSystemProfilePrivilege. Providers may be named (\"Microsoft-Windows-DotNETRuntime\") or GUID-formatted. Kernel keywords use KernelTraceEventParser.Keywords names (Process, ImageLoad, Thread, DiskIO, NetworkTCPIP, ContextSwitch, …). Events are streamed to the output .etl until trace.stop.")]
+    public Task<TraceStartResult> TraceStart(
+        [Description("Start options. Providers + optional kernel keywords + optional output path.")] TraceStartOptions options,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(_trace.Start(options));
+    }
+
+    [McpServerTool(Name = "trace.stop")]
+    [Description("Stop an ETW trace session by id. Flushes the .etl and returns the final file size and duration.")]
+    public Task<TraceStopResult> TraceStop(
+        [Description("Session id from trace.start.")] string sessionId,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(_trace.Stop(sessionId));
+    }
+
+    [McpServerTool(Name = "trace.report")]
+    [Description("Summarize a .etl file: total event count, wall-clock duration, per-provider event counts, and the top N (provider, event) pairs by frequency. Uses Microsoft.Diagnostics.Tracing.TraceEvent; does not require admin.")]
+    public Task<TraceReport> TraceReport(
+        [Description("Absolute path to a .etl file.")] string path,
+        [Description("Max (provider, event) pairs to return (1..1000, default 20).")] int top = 20,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(_trace.Report(path, top));
     }
 }

--- a/src/VSMCP.Shared/M8cDtos.cs
+++ b/src/VSMCP.Shared/M8cDtos.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+/// <summary>Result of <c>counters.subscribe</c>: a handle to an active polling subscription.</summary>
+public sealed class CountersSubscriptionHandle
+{
+    public string SubscriptionId { get; set; } = "";
+    public int Pid { get; set; }
+    public string ProcessName { get; set; } = "";
+    public int SampleMs { get; set; }
+    public int BufferSize { get; set; }
+    public string StartedUtc { get; set; } = "";
+}
+
+/// <summary>Result of <c>counters.read</c>: any samples buffered since the last read.</summary>
+public sealed class CountersReadResult
+{
+    public string SubscriptionId { get; set; } = "";
+    public List<CountersSnapshot> Samples { get; set; } = new();
+    /// <summary>Number of samples that had to be dropped because the ring buffer wrapped.</summary>
+    public long Dropped { get; set; }
+    /// <summary>True when the polling task has ended (process exited, subscription canceled).</summary>
+    public bool Ended { get; set; }
+    /// <summary>Reason the subscription ended, if any (process_exit, canceled, error).</summary>
+    public string? EndReason { get; set; }
+}
+
+/// <summary>Result of <c>counters.unsubscribe</c>.</summary>
+public sealed class CountersUnsubscribeResult
+{
+    public string SubscriptionId { get; set; } = "";
+    public long TotalSamples { get; set; }
+    public long Dropped { get; set; }
+    public double DurationSeconds { get; set; }
+}

--- a/src/VSMCP.Shared/M8dDtos.cs
+++ b/src/VSMCP.Shared/M8dDtos.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+/// <summary>Options for <c>trace.start</c>: which ETW providers to enable and where to write the .etl.</summary>
+public sealed class TraceStartOptions
+{
+    /// <summary>
+    /// User-mode ETW providers to enable. Each entry is either a GUID or a registered provider name
+    /// (e.g. "Microsoft-Windows-DotNETRuntime", "Microsoft-Windows-Kernel-Process"). Empty = no user providers.
+    /// </summary>
+    public List<TraceProviderSpec> Providers { get; set; } = new();
+
+    /// <summary>
+    /// Kernel keywords to enable (e.g. "Process,ImageLoad,Thread"). Null/empty = no kernel provider.
+    /// Valid names map to <c>KernelTraceEventParser.Keywords</c>. Requires the session to run as admin.
+    /// </summary>
+    public List<string>? KernelKeywords { get; set; }
+
+    /// <summary>Absolute path of the .etl to write. Omit to auto-generate under %TEMP%.</summary>
+    public string? OutputPath { get; set; }
+
+    /// <summary>Optional circular buffer size in MB. Omit to use TraceEvent's default.</summary>
+    public int? BufferSizeMB { get; set; }
+}
+
+public sealed class TraceProviderSpec
+{
+    /// <summary>Provider name ("Microsoft-Windows-DotNETRuntime") or GUID ("{e13c0d23-ccbc-4e12-931b-d9cc2eee27e4}").</summary>
+    public string Name { get; set; } = "";
+    /// <summary>Event level 1..5. 0 means "default/informational".</summary>
+    public int Level { get; set; } = 4;
+    /// <summary>Keyword bitmask. 0 means "all keywords".</summary>
+    public long Keywords { get; set; } = -1;
+}
+
+public sealed class TraceStartResult
+{
+    public string SessionId { get; set; } = "";
+    public string OutputPath { get; set; } = "";
+    public string StartedUtc { get; set; } = "";
+    /// <summary>Whether a kernel provider was enabled in addition to user providers.</summary>
+    public bool KernelEnabled { get; set; }
+    public List<string> ProvidersEnabled { get; set; } = new();
+}
+
+public sealed class TraceStopResult
+{
+    public string SessionId { get; set; } = "";
+    public string OutputPath { get; set; } = "";
+    public long BytesWritten { get; set; }
+    public double DurationSeconds { get; set; }
+}
+
+public sealed class TraceEventCount
+{
+    public string Provider { get; set; } = "";
+    public string EventName { get; set; } = "";
+    public long Count { get; set; }
+}
+
+public sealed class TraceReport
+{
+    public string Path { get; set; } = "";
+    public double DurationSeconds { get; set; }
+    public long TotalEvents { get; set; }
+    public List<TraceEventCount> TopEvents { get; set; } = new();
+    public Dictionary<string, long> EventsByProvider { get; set; } = new();
+    /// <summary>True when the .etl could not be read or contained no events.</summary>
+    public bool Empty { get; set; }
+}


### PR DESCRIPTION
## Summary
Closes the streaming half of M8.

- **counters.subscribe / counters.read / counters.unsubscribe** — background poller on the Server side. Samples process-level counters (CPU%, WS, private/virtual/paged mem, thread/handle counts, uptime) into a 256-slot ring buffer. Clients drain on demand; the subscription ends automatically on process exit.
- **trace.start / trace.stop / trace.report** — TraceEventSession wrapper around system-wide ETW. Accepts named or GUID user-mode providers plus optional kernel keywords (Process, ImageLoad, Thread, etc.). Streams a .etl to disk; report aggregates top (provider, event) pairs by frequency and per-provider counts. Admin required — user-mode ETW needs SeSystemProfilePrivilege; error message points at profiler.start for the admin-free path.

## Test plan
- [ ] counters.subscribe(pid, 500) → counters.read returns growing samples; counters.unsubscribe stops the loop
- [ ] Kill the target — subscription reports Ended=true, EndReason="process_exit"
- [ ] trace.start without admin returns a clear error naming the missing privilege
- [ ] trace.start with `Microsoft-Windows-DotNETRuntime` and a short workload → trace.stop writes a non-empty .etl → trace.report lists GC/exception events at the top

Closes #8.