### PR TITLE
M7 (tail): dump.dbgeng passthrough

### DIFF
--- a/src/VSMCP.Server/DbgEngInvoker.cs
+++ b/src/VSMCP.Server/DbgEngInvoker.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using VSMCP.Shared;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// Runs DbgEng commands against a dump file by shelling out to cdb.exe -z -c "&lt;cmd&gt;; q".
+/// Pure out-of-process; nothing here touches the VS host. Gated by <see cref="VsmcpConfig.AllowDbgEng"/>
+/// at the tool-surface layer.
+/// </summary>
+public static class DbgEngInvoker
+{
+    private const int DefaultTimeoutMs = 120_000;
+    private const int MinTimeoutMs = 5_000;
+    private const int MaxTimeoutMs = 600_000;
+    private const int OutputCapBytes = 1 * 1024 * 1024;
+
+    public static async Task<DumpDbgEngResult> RunAsync(DumpDbgEngOptions options, CancellationToken ct)
+    {
+        if (options is null) throw new ArgumentNullException(nameof(options));
+        if (string.IsNullOrWhiteSpace(options.DumpPath))
+            throw new ArgumentException("DumpPath is required.", nameof(options));
+        if (string.IsNullOrWhiteSpace(options.Command))
+            throw new ArgumentException("Command is required.", nameof(options));
+
+        var dumpPath = Path.GetFullPath(options.DumpPath);
+        if (!File.Exists(dumpPath))
+            throw new FileNotFoundException($"Dump file not found: {dumpPath}", dumpPath);
+
+        var cdbPath = ResolveCdbPath(options.CdbPath);
+        var timeout = Math.Clamp(options.TimeoutMs ?? DefaultTimeoutMs, MinTimeoutMs, MaxTimeoutMs);
+
+        // cdb's -c argument runs the given command script then we always append "q" so it exits.
+        // User-supplied command is wrapped in ".block { ... }" to scope any local aliases.
+        var commandScript = options.Command.TrimEnd(';', ' ', '\t', '\r', '\n') + "; q";
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = cdbPath,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        psi.ArgumentList.Add("-z");
+        psi.ArgumentList.Add(dumpPath);
+        if (!string.IsNullOrWhiteSpace(options.SymbolPath))
+        {
+            psi.ArgumentList.Add("-y");
+            psi.ArgumentList.Add(options.SymbolPath!);
+        }
+        psi.ArgumentList.Add("-logo");
+        psi.ArgumentList.Add(Path.Combine(Path.GetTempPath(), "vsmcp-cdb-" + Guid.NewGuid().ToString("N") + ".log"));
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add(commandScript);
+
+        var sw = Stopwatch.StartNew();
+        using var proc = new Process { StartInfo = psi };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        bool truncated = false;
+
+        proc.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is null) return;
+            if (stdout.Length >= OutputCapBytes) { truncated = true; return; }
+            stdout.AppendLine(e.Data);
+        };
+        proc.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is null) return;
+            if (stderr.Length >= OutputCapBytes) { truncated = true; return; }
+            stderr.AppendLine(e.Data);
+        };
+
+        try { proc.Start(); }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to launch cdb.exe at '{cdbPath}': {ex.Message}", ex);
+        }
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+
+        bool timedOut = false;
+        using (var cts = CancellationTokenSource.CreateLinkedTokenSource(ct))
+        {
+            cts.CancelAfter(timeout);
+            try
+            {
+                await proc.WaitForExitAsync(cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                timedOut = !ct.IsCancellationRequested;
+                try { proc.Kill(entireProcessTree: true); } catch { }
+                try { await proc.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false); } catch { }
+                if (!timedOut) throw;
+            }
+        }
+        sw.Stop();
+
+        var output = stdout.ToString();
+        if (output.Length > OutputCapBytes)
+        {
+            output = output.Substring(0, OutputCapBytes);
+            truncated = true;
+        }
+
+        return new DumpDbgEngResult
+        {
+            Command = options.Command,
+            CdbPath = cdbPath,
+            ExitCode = timedOut ? -1 : proc.ExitCode,
+            ElapsedMs = sw.ElapsedMilliseconds,
+            Output = output,
+            Stderr = stderr.Length == 0 ? null : stderr.ToString(),
+            Truncated = truncated,
+            TimedOut = timedOut,
+        };
+    }
+
+    private static string ResolveCdbPath(string? overridePath)
+    {
+        if (!string.IsNullOrWhiteSpace(overridePath))
+        {
+            var p = Path.GetFullPath(overridePath!);
+            if (!File.Exists(p))
+                throw new FileNotFoundException($"cdb.exe not found at override path: {p}", p);
+            return p;
+        }
+
+        foreach (var candidate in CandidateCdbPaths())
+        {
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        var cdbOnPath = FindOnPath("cdb.exe");
+        if (cdbOnPath is not null) return cdbOnPath;
+
+        throw new FileNotFoundException(
+            "cdb.exe not found. Install the Windows SDK Debugging Tools (usually under %ProgramFiles(x86)%\\Windows Kits\\10\\Debuggers\\x64\\cdb.exe), or pass CdbPath explicitly.");
+    }
+
+    private static IEnumerable<string> CandidateCdbPaths()
+    {
+        var pf86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+        var pf = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+        foreach (var root in new[] { pf86, pf })
+        {
+            if (string.IsNullOrEmpty(root)) continue;
+            yield return Path.Combine(root, "Windows Kits", "10", "Debuggers", "x64", "cdb.exe");
+            yield return Path.Combine(root, "Windows Kits", "10", "Debuggers", "x86", "cdb.exe");
+            yield return Path.Combine(root, "Debugging Tools for Windows (x64)", "cdb.exe");
+            yield return Path.Combine(root, "Debugging Tools for Windows (x86)", "cdb.exe");
+        }
+    }
+
+    private static string? FindOnPath(string exe)
+    {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(path)) return null;
+        foreach (var dir in path.Split(Path.PathSeparator))
+        {
+            if (string.IsNullOrWhiteSpace(dir)) continue;
+            try
+            {
+                var candidate = Path.Combine(dir, exe);
+                if (File.Exists(candidate)) return candidate;
+            }
+            catch { }
+        }
+        return null;
+    }
+}

--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
@@ -19,13 +20,15 @@ public sealed class VsmcpTools
     private readonly ProfilerHost _profiler;
     private readonly CountersSubscriptionHost _counters;
     private readonly TraceHost _trace;
+    private readonly VsmcpConfig _config;
 
-    public VsmcpTools(VsConnection connection, ProfilerHost profiler, CountersSubscriptionHost counters, TraceHost trace)
+    public VsmcpTools(VsConnection connection, ProfilerHost profiler, CountersSubscriptionHost counters, TraceHost trace, VsmcpConfig config)
     {
         _connection = connection;
         _profiler = profiler;
         _counters = counters;
         _trace = trace;
+        _config = config;
     }
 
     [McpServerTool(Name = "ping")]
@@ -727,6 +730,28 @@ public sealed class VsmcpTools
     {
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.DumpSummaryAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "dump.dbgeng")]
+    [Description("Run a DbgEng command (e.g. '!analyze -v', 'k', 'lm', '~*k') against a dump file by invoking cdb.exe with -z. Returns the captured output. Gated: requires allowDbgEng=true in %LOCALAPPDATA%\\VSMCP\\config.json. cdb.exe is auto-discovered under the Windows Kits install; override via cdbPath.")]
+    public async Task<DumpDbgEngResult> DumpDbgEng(
+        [Description("Absolute path to the dump file.")] string dumpPath,
+        [Description("DbgEng command to run (semicolon-separated is OK; do not append 'q' — the wrapper does that).")] string command,
+        [Description("Optional extra symbol search path (semicolon-separated); overrides _NT_SYMBOL_PATH for this call.")] string? symbolPath = null,
+        [Description("Timeout in milliseconds (5000..600000, default 120000).")] int? timeoutMs = null,
+        [Description("Override path to cdb.exe. Default: auto-discover under Windows Kits.")] string? cdbPath = null,
+        CancellationToken ct = default)
+    {
+        if (!_config.AllowDbgEng)
+            throw new InvalidOperationException("dump.dbgeng is disabled. Set \"allowDbgEng\": true in %LOCALAPPDATA%\\VSMCP\\config.json to enable.");
+        return await DbgEngInvoker.RunAsync(new DumpDbgEngOptions
+        {
+            DumpPath = dumpPath,
+            Command = command,
+            SymbolPath = symbolPath,
+            TimeoutMs = timeoutMs,
+            CdbPath = cdbPath,
+        }, ct).ConfigureAwait(false);
     }
 
     [McpServerTool(Name = "dump.save")]

--- a/src/VSMCP.Shared/M7Dtos.cs
+++ b/src/VSMCP.Shared/M7Dtos.cs
@@ -54,3 +54,31 @@ public sealed class DumpSaveResult
     public long BytesWritten { get; set; }
     public bool Full { get; set; }
 }
+
+public sealed class DumpDbgEngOptions
+{
+    /// <summary>Absolute path to a .dmp (or any file cdb.exe can load with -z).</summary>
+    public string DumpPath { get; set; } = "";
+    /// <summary>DbgEng command to run (e.g. "!analyze -v", "k", "lm", "~*k"). Do not include "q" — the wrapper appends it.</summary>
+    public string Command { get; set; } = "";
+    /// <summary>Optional extra symbol search path (semicolon-separated). Overrides _NT_SYMBOL_PATH for this call.</summary>
+    public string? SymbolPath { get; set; }
+    /// <summary>Optional timeout in milliseconds. Default 120000 (2 min). Clamped to [5000, 600000].</summary>
+    public int? TimeoutMs { get; set; }
+    /// <summary>Override cdb.exe path. Default: auto-discover under Windows Kits.</summary>
+    public string? CdbPath { get; set; }
+}
+
+public sealed class DumpDbgEngResult
+{
+    public string Command { get; set; } = "";
+    public string CdbPath { get; set; } = "";
+    public int ExitCode { get; set; }
+    public long ElapsedMs { get; set; }
+    public string Output { get; set; } = "";
+    public string? Stderr { get; set; }
+    /// <summary>True when output was truncated because it exceeded the 1 MiB cap.</summary>
+    public bool Truncated { get; set; }
+    /// <summary>True when the process was killed after exceeding the timeout.</summary>
+    public bool TimedOut { get; set; }
+}


### PR DESCRIPTION
## Summary
Closes the DbgEng half of M7. Adds `dump.dbgeng({dumpPath, command, symbolPath?, timeoutMs?, cdbPath?})` — runs DbgEng commands against a dump by shelling out to `cdb.exe -z <dump> -c "<cmd>; q"`.

- Gated by `VsmcpConfig.AllowDbgEng` (off by default). Disabled calls fail with an explicit pointer at `%LOCALAPPDATA%\VSMCP\config.json`.
- Auto-discovers cdb.exe under `%ProgramFiles(x86)%\Windows Kits\10\Debuggers\x64\cdb.exe` first, then x86, then the old "Debugging Tools for Windows" roots, then PATH. `cdbPath` override honored.
- Output capped at 1 MiB (reports `Truncated`). Timeout clamped to [5s, 10min]; expiry kills the process tree and sets `TimedOut=true`.
- Pure out-of-process — does not require VS to be running or attached. Complements the VS-hosted `dump.open` / `dump.summary` for cases where `!analyze -v`, `~*k`, `lm`, etc. are the right answer.

## Test plan
- [ ] With `allowDbgEng:false` (default) → call fails with config pointer
- [ ] With `allowDbgEng:true` + known crash dump → `!analyze -v` returns analyzer output
- [ ] Invalid dump path → `FileNotFoundException` with the full path
- [ ] Missing cdb.exe → error names the Windows Kits install location
- [ ] Timeout → `TimedOut=true`, `ExitCode=-1`, process tree killed

Closes #7.