### PR TITLE
M11 (tail): fixture projects under tests/Skills/

### DIFF
--- a/tests/Skills/HelloCrash/HelloCrash.csproj
+++ b/tests/Skills/HelloCrash/HelloCrash.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>HelloCrash</RootNamespace>
+    <AssemblyName>HelloCrash</AssemblyName>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/Skills/HelloCrash/Program.cs
+++ b/tests/Skills/HelloCrash/Program.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace HelloCrash;
+
+internal static class Program
+{
+    private static void Main(string[] args)
+    {
+        Console.WriteLine("HelloCrash starting. About to dereference a null…");
+        var mode = args.Length > 0 ? args[0] : "nre";
+        switch (mode)
+        {
+            case "nre":
+                CrashWithNullDeref();
+                break;
+            case "aoor":
+                CrashWithIndexOutOfRange();
+                break;
+            case "stack":
+                Recurse(0);
+                break;
+            default:
+                Console.WriteLine($"Unknown mode '{mode}'. Use: nre | aoor | stack.");
+                return;
+        }
+    }
+
+    private static void CrashWithNullDeref()
+    {
+        string s = null;
+        Console.WriteLine(s.Length);
+    }
+
+    private static void CrashWithIndexOutOfRange()
+    {
+        var a = new int[3];
+        Console.WriteLine(a[42]);
+    }
+
+    private static int Recurse(int depth) => Recurse(depth + 1) + 1;
+}

--- a/tests/Skills/HotLoop/HotLoop.csproj
+++ b/tests/Skills/HotLoop/HotLoop.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>HotLoop</RootNamespace>
+    <AssemblyName>HotLoop</AssemblyName>
+    <Nullable>disable</Nullable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+  </PropertyGroup>
+</Project>

--- a/tests/Skills/HotLoop/Program.cs
+++ b/tests/Skills/HotLoop/Program.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+
+namespace HotLoop;
+
+internal static class Program
+{
+    private static volatile bool _stop;
+
+    private static void Main(string[] args)
+    {
+        Console.CancelKeyPress += (_, e) => { _stop = true; e.Cancel = true; };
+        var mode = args.Length > 0 ? args[0] : "cpu";
+        Console.WriteLine($"HotLoop starting in '{mode}' mode. PID={Environment.ProcessId}. Ctrl+C to stop.");
+        switch (mode)
+        {
+            case "cpu":
+                BurnCpu();
+                break;
+            case "alloc":
+                Allocate();
+                break;
+            case "mixed":
+                Mixed();
+                break;
+            default:
+                Console.WriteLine("Unknown mode. Use: cpu | alloc | mixed.");
+                return;
+        }
+    }
+
+    private static void BurnCpu()
+    {
+        double acc = 0;
+        long n = 0;
+        while (!_stop)
+        {
+            acc += Math.Sqrt(n++) * Math.Sin(n) + Math.Cos(n * 0.5);
+            if ((n & 0xFFFFFFF) == 0) Console.WriteLine($"n={n} acc={acc:G4}");
+        }
+    }
+
+    private static void Allocate()
+    {
+        var sink = new System.Collections.Generic.List<byte[]>();
+        long total = 0;
+        while (!_stop)
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                sink.Add(new byte[1024]);
+                total += 1024;
+            }
+            if (sink.Count > 100_000) sink.RemoveRange(0, 50_000);
+            Thread.Sleep(1);
+            if ((total & ((1L << 26) - 1)) < 1_000_000)
+                Console.WriteLine($"live-ish={sink.Count:N0} total-allocated={total:N0}B");
+        }
+    }
+
+    private static void Mixed()
+    {
+        var t = new Thread(BurnCpu) { IsBackground = true, Name = "CpuBurner" };
+        t.Start();
+        Allocate();
+        t.Join(TimeSpan.FromSeconds(2));
+    }
+}

--- a/tests/Skills/NativeConsole/NativeConsole.vcxproj
+++ b/tests/Skills/NativeConsole/NativeConsole.vcxproj
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <ProjectGuid>{B4444444-4444-4444-4444-444444444444}</ProjectGuid>
+    <RootNamespace>NativeConsole</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <Optimization>MaxSpeed</Optimization>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/tests/Skills/NativeConsole/main.cpp
+++ b/tests/Skills/NativeConsole/main.cpp
@@ -1,0 +1,49 @@
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+static void crash_null_deref() {
+    char* p = nullptr;
+    std::printf("about to write through nullptr\n");
+    p[0] = 'x'; // 0xC0000005
+}
+
+static void crash_stack_overflow() {
+    volatile char buf[1024];
+    buf[0] = 0;
+    crash_stack_overflow();
+}
+
+static void crash_use_after_free() {
+    char* p = static_cast<char*>(std::malloc(16));
+    std::strcpy(p, "alive");
+    std::printf("before free: %s\n", p);
+    std::free(p);
+    // May or may not crash depending on allocator; reading freed memory commonly yields 0xDDDDDDDD in debug builds.
+    std::printf("after free: %s\n", p);
+    p[0] = 'Z';
+}
+
+static void crash_heap_corruption() {
+    char* p = static_cast<char*>(std::malloc(8));
+    // Write past the end to corrupt the CRT heap header.
+    for (int i = 0; i < 64; ++i) p[i] = static_cast<char>(0xCC);
+    std::free(p);
+}
+
+int main(int argc, char** argv) {
+    const char* mode = argc > 1 ? argv[1] : "null";
+    std::printf("NativeConsole mode=%s pid=%lu\n", mode, static_cast<unsigned long>(_getpid()));
+
+    std::string m = mode;
+    if (m == "null")       crash_null_deref();
+    else if (m == "stack") crash_stack_overflow();
+    else if (m == "uaf")   crash_use_after_free();
+    else if (m == "heap")  crash_heap_corruption();
+    else {
+        std::printf("unknown mode. use: null | stack | uaf | heap\n");
+        return 2;
+    }
+    return 0;
+}

--- a/tests/Skills/README.md
+++ b/tests/Skills/README.md
@@ -1,0 +1,53 @@
+# VSMCP skill fixtures
+
+Tiny projects that give each Claude Skill playbook a deterministic target. Not part of the product; not wired into `VSMCP.sln`. Build them only when you want to exercise the skills end-to-end against a known repro.
+
+| Fixture | Language | Binds to skill | Repro |
+| --- | --- | --- | --- |
+| `HelloCrash/` | .NET 9 | `Debug`, `DebugCrash` | Null deref / out-of-range / stack overflow (`--` `nre` \| `aoor` \| `stack`) |
+| `HotLoop/` | .NET 9 | `DebugPerf`, `DebugMemory` | CPU burn / alloc churn / mixed (`cpu` \| `alloc` \| `mixed`) |
+| `NativeConsole/` | C++17 (v143, x64) | `DebugNative`, `DebugCrash` | Null deref / stack overflow / use-after-free / heap corruption (`null` \| `stack` \| `uaf` \| `heap`) |
+
+## Build & run
+
+```bash
+# Managed fixtures
+dotnet run --project tests/Skills/HelloCrash -- nre
+dotnet run --project tests/Skills/HotLoop    -- cpu
+
+# Native fixture (requires the "Desktop development with C++" workload)
+msbuild tests/Skills/NativeConsole/NativeConsole.vcxproj -p:Configuration=Debug -p:Platform=x64
+.\tests\Skills\NativeConsole\x64\Debug\NativeConsole.exe null
+```
+
+## Intended skill exercises
+
+### `Debug` against HelloCrash
+1. `bp.set({kind:"Line", file:"…/HelloCrash/Program.cs", line:<CrashWithNullDeref open brace>})`.
+2. `debug.launch({projectId:"HelloCrash"})`.
+3. When `Mode=Break`, `frame.locals` should show `s` as `null`.
+
+### `DebugCrash` against HelloCrash
+1. Run HelloCrash with WER dump capture enabled (or `dump.save` from a sibling VS).
+2. `dump.open({path})` → `dump.summary` surfaces the NRE.
+3. `stack.get` + `frame.locals` on top frame confirms the null.
+4. With `allowDbgEng:true`, `dump.dbgeng({dumpPath, command:"!analyze -v"})` should label the fault as `NULL_POINTER_READ` or equivalent.
+
+### `DebugPerf` against HotLoop `cpu`
+1. `processes.list({nameContains:"HotLoop"})` → pid.
+2. `profiler.start({pid, mode:"CpuSampling"})` → run ~10s → `profiler.stop` → `profiler.report`.
+3. `BurnCpu` should dominate the hot list.
+
+### `DebugMemory` against HotLoop `alloc`
+1. `counters.subscribe({pid, sampleMs:500})`.
+2. After ~30s, `counters.read` — working set/private bytes should be climbing and settling (not a true leak, it's capped).
+3. `profiler.start({pid, mode:"Allocations"})` → `Allocate` should dominate allocation samples.
+
+### `DebugNative` against NativeConsole `null`
+1. `debug.attach({pid, engines:["Native"]})` (or launch with the native engine).
+2. On the AV, `registers.get` → RIP in `crash_null_deref`.
+3. `memory.read` around the faulting address shows zero page.
+
+## What this is not
+
+These fixtures are not an automated test suite — they're **manual skill exercises**. Success criteria is "the skill playbook reaches the expected hand-back state without guesswork". A proper automated suite would drive VSMCP over its pipe and assert on tool results; that's out of scope for M11.


### PR DESCRIPTION
## Summary
Adds three minimal fixture projects so each Claude Skill has a deterministic repro target.

| Fixture | Bindings | Modes |
| --- | --- | --- |
| HelloCrash (.NET 9) | Debug, DebugCrash | `nre` · `aoor` · `stack` |
| HotLoop (.NET 9) | DebugPerf, DebugMemory | `cpu` · `alloc` · `mixed` |
| NativeConsole (C++17 v143 x64) | DebugNative, DebugCrash | `null` · `stack` · `uaf` · `heap` |

`tests/Skills/README.md` spells out the per-skill exercise and the hand-back state each playbook should reach. These are manual fixtures, not an automated test harness — a proper e2e suite that drives VSMCP over its pipe stays deferred.

## Test plan
- [x] Managed fixtures build clean (`dotnet build tests/Skills/HelloCrash` and `…/HotLoop`)
- [ ] Native fixture builds on a box with the "Desktop development with C++" workload
- [ ] Each fixture mode produces the documented failure/hot-path signal