### PR TITLE
vs.focus + teaching-mode auto-focus

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -47,6 +47,32 @@ public sealed class VsmcpTools
         return await proxy.GetStatusAsync(ct).ConfigureAwait(false);
     }
 
+    [McpServerTool(Name = "vs.focus")]
+    [Description("Bring the connected Visual Studio main window to the foreground. Useful for teaching/demos when the human needs to see the IDE react to an AI tool call.")]
+    public async Task<FocusResult> VsFocus(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.VsFocusAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "vs.set_autofocus")]
+    [Description("Toggle teaching-mode auto-focus. When enabled, every dispatched tool call raises the VS window so an observer always sees the effect. Default: enabled.")]
+    public async Task<AutoFocusResult> VsSetAutoFocus(
+        [Description("True to auto-focus after every tool call (teaching mode); false to suppress.")] bool enabled,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.VsSetAutoFocusAsync(enabled, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "vs.get_autofocus")]
+    [Description("Return whether teaching-mode auto-focus is currently enabled on the connected VS instance.")]
+    public async Task<AutoFocusResult> VsGetAutoFocus(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.VsGetAutoFocusAsync(ct).ConfigureAwait(false);
+    }
+
     [McpServerTool(Name = "vs.list_instances")]
     [Description("Enumerate running Visual Studio instances that have the VSMCP extension loaded. Use this when multiple VS windows are open.")]
     public Task<System.Collections.Generic.IReadOnlyList<VsInstance>> VsListInstances(CancellationToken ct = default)

--- a/src/VSMCP.Shared/Dtos.cs
+++ b/src/VSMCP.Shared/Dtos.cs
@@ -38,3 +38,15 @@ public sealed class VsInstance
     public string? MainWindowTitle { get; set; }
     public string? SolutionPath { get; set; }
 }
+
+public sealed class FocusResult
+{
+    public bool Focused { get; set; }
+    public string? Hwnd { get; set; }
+    public string? Reason { get; set; }
+}
+
+public sealed class AutoFocusResult
+{
+    public bool Enabled { get; set; }
+}

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -14,6 +14,9 @@ public interface IVsmcpRpc
     Task<HandshakeResult> HandshakeAsync(int clientMajor, int clientMinor, CancellationToken cancellationToken = default);
     Task<PingResult> PingAsync(CancellationToken cancellationToken = default);
     Task<VsStatus> GetStatusAsync(CancellationToken cancellationToken = default);
+    Task<FocusResult> VsFocusAsync(CancellationToken cancellationToken = default);
+    Task<AutoFocusResult> VsSetAutoFocusAsync(bool enabled, CancellationToken cancellationToken = default);
+    Task<AutoFocusResult> VsGetAutoFocusAsync(CancellationToken cancellationToken = default);
 
     // -------- Solution --------
     Task<SolutionInfo> SolutionInfoAsync(CancellationToken cancellationToken = default);

--- a/src/VSMCP.Vsix/FocusHelper.cs
+++ b/src/VSMCP.Vsix/FocusHelper.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using EnvDTE80;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Threading;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// Brings the host VS main window to the foreground. Used for the explicit <c>vs.focus</c> tool and
+/// for auto-focus after every dispatched RPC (teaching mode). Safe to call when VS is already on top.
+/// </summary>
+internal static class FocusHelper
+{
+    public static async Task ActivateAsync(VSMCPPackage package, JoinableTaskFactory jtf, CancellationToken ct = default)
+    {
+        try
+        {
+            await jtf.SwitchToMainThreadAsync(ct);
+            if (await package.GetServiceAsync(typeof(EnvDTE.DTE)) is not DTE2 dte) return;
+
+            var window = dte.MainWindow;
+            if (window is null) return;
+
+            try { window.Visible = true; } catch { }
+            try { window.Activate(); } catch { }
+
+            // DTE.MainWindow.Activate() is courteous — Win32 foreground-stealing prevention can reduce
+            // it to a taskbar flash. Since we're the foreground of our own process already, an explicit
+            // SetForegroundWindow on the VS top-level HWND is allowed and reliably raises the window.
+            IntPtr hwnd = IntPtr.Zero;
+            try
+            {
+                object raw = window.HWnd;
+                hwnd = raw switch
+                {
+                    IntPtr ip => ip,
+                    int i32 => new IntPtr(i32),
+                    long i64 => new IntPtr(i64),
+                    _ => IntPtr.Zero,
+                };
+            }
+            catch { }
+            if (hwnd != IntPtr.Zero)
+            {
+                if (IsIconic(hwnd)) ShowWindow(hwnd, SW_RESTORE);
+                SetForegroundWindow(hwnd);
+                BringWindowToTop(hwnd);
+            }
+        }
+        catch
+        {
+            // Focus is best-effort; never fail an RPC because the window couldn't be raised.
+        }
+    }
+
+    private const int SW_RESTORE = 9;
+
+    [DllImport("user32.dll")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool BringWindowToTop(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool IsIconic(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+}

--- a/src/VSMCP.Vsix/PipeHost.cs
+++ b/src/VSMCP.Vsix/PipeHost.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.IO.Pipes;
 using System.Security.AccessControl;
 using System.Security.Principal;
@@ -6,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Threading;
 using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
 using VSMCP.Shared;
 
 namespace VSMCP.Vsix;
@@ -44,7 +46,7 @@ internal sealed class PipeHost : IDisposable
                 await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
 
                 var target = new RpcTarget(_package, _jtf);
-                var rpc = JsonRpc.Attach(server, target);
+                var rpc = AttachWithAutoFocus(server, target);
                 // Each connection owns its own stream; don't await Completion here — we want to
                 // accept the next connection immediately. The rpc/stream dispose together.
                 _ = rpc.Completion.ContinueWith(_ => server.Dispose(), TaskScheduler.Default);
@@ -82,5 +84,61 @@ internal sealed class PipeHost : IDisposable
     {
         try { _cts.Cancel(); } catch { }
         _cts.Dispose();
+    }
+
+    private JsonRpc AttachWithAutoFocus(Stream stream, RpcTarget target)
+    {
+        var handler = new HeaderDelimitedMessageHandler(stream);
+        var rpc = new AutoFocusJsonRpc(handler, _package, _jtf, target);
+        rpc.AddLocalRpcTarget(target);
+        rpc.StartListening();
+        return rpc;
+    }
+
+    /// <summary>
+    /// JsonRpc variant that brings VS to the foreground after every dispatched request.
+    /// Teaching-mode default: on. Each VSIX-dispatched tool call makes the IDE visible so
+    /// a student watching alongside an AI session always sees the effect.
+    /// </summary>
+    private sealed class AutoFocusJsonRpc : JsonRpc
+    {
+        private readonly VSMCPPackage _package;
+        private readonly JoinableTaskFactory _jtf;
+        private readonly RpcTarget _target;
+
+        public AutoFocusJsonRpc(IJsonRpcMessageHandler handler, VSMCPPackage package, JoinableTaskFactory jtf, RpcTarget target)
+            : base(handler)
+        {
+            _package = package;
+            _jtf = jtf;
+            _target = target;
+        }
+
+        protected override async ValueTask<JsonRpcMessage> DispatchRequestAsync(JsonRpcRequest request, TargetMethod targetMethod, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await base.DispatchRequestAsync(request, targetMethod, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (_target.AutoFocusEnabled && !SkipFocus(request?.Method))
+                {
+                    try { await FocusHelper.ActivateAsync(_package, _jtf, cancellationToken).ConfigureAwait(false); } catch { }
+                }
+            }
+        }
+
+        private static bool SkipFocus(string? method)
+        {
+            if (string.IsNullOrEmpty(method)) return true;
+            // Skip ultra-high-frequency / meta calls that would cause focus thrash without teaching value.
+            return method switch
+            {
+                "HandshakeAsync" => true,
+                "PingAsync" => true,
+                _ => false,
+            };
+        }
     }
 }

--- a/src/VSMCP.Vsix/RpcTarget.Focus.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Focus.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EnvDTE80;
+using VSMCP.Shared;
+
+namespace VSMCP.Vsix;
+
+internal sealed partial class RpcTarget
+{
+    public async Task<FocusResult> VsFocusAsync(CancellationToken cancellationToken = default)
+    {
+        await FocusHelper.ActivateAsync(_package, _jtf, cancellationToken).ConfigureAwait(false);
+
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        string? hwnd = null;
+        if (await _package.GetServiceAsync(typeof(EnvDTE.DTE)) is DTE2 dte && dte.MainWindow is { } win)
+        {
+            try
+            {
+                object raw = win.HWnd;
+                long value = raw switch
+                {
+                    IntPtr ip => ip.ToInt64(),
+                    int i32 => i32,
+                    long i64 => i64,
+                    _ => 0,
+                };
+                hwnd = "0x" + value.ToString("X");
+            }
+            catch { }
+        }
+
+        return new FocusResult { Focused = true, Hwnd = hwnd };
+    }
+
+    public Task<AutoFocusResult> VsSetAutoFocusAsync(bool enabled, CancellationToken cancellationToken = default)
+    {
+        AutoFocusEnabled = enabled;
+        return Task.FromResult(new AutoFocusResult { Enabled = AutoFocusEnabled });
+    }
+
+    public Task<AutoFocusResult> VsGetAutoFocusAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new AutoFocusResult { Enabled = AutoFocusEnabled });
+}

--- a/src/VSMCP.Vsix/RpcTarget.cs
+++ b/src/VSMCP.Vsix/RpcTarget.cs
@@ -19,6 +19,12 @@ internal sealed partial class RpcTarget : IVsmcpRpc
     private readonly VSMCPPackage _package;
     private readonly JoinableTaskFactory _jtf;
 
+    /// <summary>
+    /// Teaching mode: when true, the pipe host raises the VS main window to the foreground
+    /// after every dispatched RPC so a human observer always sees the IDE react. Default on.
+    /// </summary>
+    public bool AutoFocusEnabled { get; set; } = true;
+
     public RpcTarget(VSMCPPackage package, JoinableTaskFactory jtf)
     {
         _package = package;

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -74,6 +74,8 @@
     <Compile Include="RpcTarget.Dump.cs" />
     <Compile Include="RpcTarget.Diagnostics.cs" />
     <Compile Include="RpcTarget.Code.cs" />
+    <Compile Include="RpcTarget.Focus.cs" />
+    <Compile Include="FocusHelper.cs" />
     <Compile Include="ModuleTracker.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />


### PR DESCRIPTION
## Summary
- Adds `vs.focus`, `vs.set_autofocus`, `vs.get_autofocus` MCP tools.
- Teaching mode: on by default. After every dispatched RPC (except `HandshakeAsync` / `PingAsync`) the VSIX raises the VS main window so a human watching alongside an AI session always sees the effect.
- Central hook via `JsonRpc.DispatchRequestAsync` override — one interception point instead of ~40 per-method focus calls. Verified via reflection that the StreamJsonRpc 2.19.27 signature is `protected virtual ValueTask<JsonRpcMessage> DispatchRequestAsync(JsonRpcRequest, TargetMethod, CancellationToken)`.
- Focus implementation: `DTE.MainWindow.Activate()` plus Win32 `SetForegroundWindow` / `BringWindowToTop` / `ShowWindow(SW_RESTORE)` on minimized windows. Swallows all exceptions — focus is best-effort and must never fail an RPC.

## Test plan
- [ ] Rebuild and install the VSIX in VS 2022 Enterprise.
- [ ] Run the bridge: `dotnet run --project src/VSMCP.Server` with a client session.
- [ ] Call any state-modifying tool (e.g. `editor.open`, `debug.break_all`) from an MCP client while VS is in the background — VS should come to the foreground after the call.
- [ ] Call `vs.set_autofocus` with `enabled=false`, repeat — VS should stay in the background.
- [ ] Call `vs.focus` explicitly — VS raises regardless of auto-focus setting.
- [ ] Confirm `ping` and handshake don't cause focus thrash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)