### PR TITLE
Batch (_many) tool variants

### DIFF
--- a/src/VSMCP.Server/VsmcpTools.Batch.cs
+++ b/src/VSMCP.Server/VsmcpTools.Batch.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+using ModelContextProtocol.Server;
+using VSMCP.Shared;
+
+namespace VSMCP.Server;
+
+/// <summary>
+/// Batch tool surface. Each *_many variant takes a list and returns a
+/// <see cref="BatchResult{T}"/> that preserves input order and captures
+/// per-item errors without failing the whole call. Calls are run sequentially
+/// because the VSIX serializes everything on the VS UI thread — parallelism
+/// offers no speedup and complicates error ordering.
+/// </summary>
+public sealed partial class VsmcpTools
+{
+    [McpServerTool(Name = "bp.set_many")]
+    [Description("Set multiple breakpoints in one call. Per-item errors are returned in the result; one bad item does not fail the others.")]
+    public async Task<BatchResult<BreakpointInfo>> BreakpointSetMany(
+        [Description("Breakpoints to create. Each item is a full BreakpointSetOptions (same schema as bp.set).")] IReadOnlyList<BreakpointSetOptions> items,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await RunBatchAsync(items, (opt, c) => proxy.BreakpointSetAsync(opt, c), ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "bp.remove_many")]
+    [Description("Remove multiple breakpoints by id. Each item's Value on success is the removed id.")]
+    public async Task<BatchResult<string>> BreakpointRemoveMany(
+        [Description("Breakpoint ids to remove.")] IReadOnlyList<string> ids,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await RunBatchAsync(ids, async (id, c) =>
+        {
+            await proxy.BreakpointRemoveAsync(id, c).ConfigureAwait(false);
+            return id;
+        }, ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "bp.enable_many")]
+    [Description("Enable multiple breakpoints by id.")]
+    public async Task<BatchResult<BreakpointInfo>> BreakpointEnableMany(
+        [Description("Breakpoint ids to enable.")] IReadOnlyList<string> ids,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await RunBatchAsync(ids, (id, c) => proxy.BreakpointEnableAsync(id, c), ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "bp.disable_many")]
+    [Description("Disable multiple breakpoints by id (without removing them).")]
+    public async Task<BatchResult<BreakpointInfo>> BreakpointDisableMany(
+        [Description("Breakpoint ids to disable.")] IReadOnlyList<string> ids,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await RunBatchAsync(ids, (id, c) => proxy.BreakpointDisableAsync(id, c), ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "eval.expression_many")]
+    [Description("Evaluate multiple expressions in one call (same EvalOptions shape as eval.expression). Useful for inspecting a set of locals in one round trip.")]
+    public async Task<BatchResult<EvalResult>> EvalExpressionMany(
+        [Description("Expressions to evaluate. Each item is a full EvalOptions.")] IReadOnlyList<EvalOptions> items,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await RunBatchAsync(items, (opt, c) => proxy.EvalExpressionAsync(opt, c), ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "file.read_many")]
+    [Description("Read multiple files (or ranges) in one call. Each item specifies a Path and optional 1-based inclusive Range.")]
+    public async Task<BatchResult<FileReadResult>> FileReadMany(
+        [Description("Files to read; each item has a required Path and optional Range.")] IReadOnlyList<FileReadRequest> items,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await RunBatchAsync(items, (req, c) => proxy.FileReadAsync(req.Path, req.Range, c), ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "memory.read_many")]
+    [Description("Read multiple memory ranges in one call. Each item specifies Address and Length; reads are capped at 64 KiB per item.")]
+    public async Task<BatchResult<MemoryReadResult>> MemoryReadMany(
+        [Description("Memory ranges to read; each item has an Address and a Length (1..65536).")] IReadOnlyList<MemoryReadRequest> items,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await RunBatchAsync(items, (req, c) => proxy.MemoryReadAsync(req.Address, req.Length, c), ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "symbols.load_many")]
+    [Description("Force-load symbols for multiple modules in one call.")]
+    public async Task<BatchResult<SymbolStatusResult>> SymbolsLoadMany(
+        [Description("Module ids from modules.list.")] IReadOnlyList<string> moduleIds,
+        CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await RunBatchAsync(moduleIds, (id, c) => proxy.SymbolsLoadAsync(id, c), ct).ConfigureAwait(false);
+    }
+
+    private static async Task<BatchResult<TOut>> RunBatchAsync<TIn, TOut>(
+        IReadOnlyList<TIn> items,
+        Func<TIn, CancellationToken, Task<TOut>> op,
+        CancellationToken ct)
+    {
+        var result = new BatchResult<TOut> { Total = items.Count };
+        for (int i = 0; i < items.Count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var entry = new BatchItemResult<TOut> { Index = i };
+            try
+            {
+                entry.Value = await op(items[i], ct).ConfigureAwait(false);
+                entry.Success = true;
+                result.Succeeded++;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                entry.Success = false;
+                entry.Error = new BatchItemError
+                {
+                    Code = ex.GetType().Name,
+                    Message = ex.Message,
+                };
+                result.Failed++;
+            }
+            result.Items.Add(entry);
+        }
+        return result;
+    }
+}

--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -14,7 +14,7 @@ namespace VSMCP.Server;
 /// <see cref="ErrorCodes.NotConnected"/> when no instance is reachable.
 /// </summary>
 [McpServerToolType]
-public sealed class VsmcpTools
+public sealed partial class VsmcpTools
 {
     private readonly VsConnection _connection;
     private readonly ProfilerHost _profiler;

--- a/src/VSMCP.Shared/BatchDtos.cs
+++ b/src/VSMCP.Shared/BatchDtos.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace VSMCP.Shared;
+
+/// <summary>
+/// Per-item result in a batch call. Exactly one of <see cref="Value"/> / <see cref="Error"/> is set.
+/// Preserves input ordering via <see cref="Index"/> so callers can correlate without threading IDs.
+/// </summary>
+public sealed class BatchItemResult<T>
+{
+    public int Index { get; set; }
+    public bool Success { get; set; }
+    public T? Value { get; set; }
+    public BatchItemError? Error { get; set; }
+}
+
+public sealed class BatchItemError
+{
+    public string Code { get; set; } = "";
+    public string Message { get; set; } = "";
+}
+
+public sealed class BatchResult<T>
+{
+    public int Total { get; set; }
+    public int Succeeded { get; set; }
+    public int Failed { get; set; }
+    public List<BatchItemResult<T>> Items { get; set; } = new();
+}
+
+public sealed class FileReadRequest
+{
+    public string Path { get; set; } = "";
+    public FileRange? Range { get; set; }
+}
+
+public sealed class MemoryReadRequest
+{
+    public string Address { get; set; } = "";
+    public int Length { get; set; }
+}


### PR DESCRIPTION
## Summary
- Adds 8 `*_many` MCP tools: `bp.set_many`, `bp.remove_many`, `bp.enable_many`, `bp.disable_many`, `eval.expression_many`, `file.read_many`, `memory.read_many`, `symbols.load_many`.
- Pure server-side fan-out — no IVsmcpRpc changes, no VSIX changes. Each item runs as a separate RPC, errors are captured per-item via `BatchItemResult<T>`.
- Sequential execution: VSIX serializes on the UI thread so parallelism would not help. Sequential also guarantees stable ordering for callers correlating by Index.
- Request DTOs added for file/memory reads (`FileReadRequest`, `MemoryReadRequest`) since those RPCs take multiple positional args.

## Test plan
- [ ] Call `bp.set_many` with a mix of valid and invalid `BreakpointSetOptions` — result should have per-item Success/Error, valid items still applied.
- [ ] Call `file.read_many` with paths pointing at open and closed files, including one bad path — bad path is the only Failure.
- [ ] Call `eval.expression_many` from a paused debug session with ~10 locals — all returned in one round trip.
- [ ] Confirm `bp.remove_many` removes all supplied ids in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)