### PR TITLE
Release workflow: tag-triggered GH Release + conditional publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (must already exist)"
+        required: true
+
+permissions:
+  contents: write
+
+env:
+  NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+jobs:
+  release:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        run: |
+          $ref = "${{ github.event.inputs.tag || github.ref_name }}"
+          $tag = $ref -replace '^refs/tags/', ''
+          $version = $tag -replace '^v', ''
+          "tag=$tag" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Releasing tag=$tag version=$version"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
+
+      - name: Restore + Build (Release)
+        shell: pwsh
+        run: |
+          msbuild src/VSMCP.sln -t:Restore,Build `
+            -p:Configuration=Release `
+            -p:Version=${{ steps.version.outputs.version }} `
+            -p:PackageVersion=${{ steps.version.outputs.version }} `
+            -v:minimal -nologo
+
+      - name: Pack VSMCP.Server (dotnet tool)
+        shell: pwsh
+        run: |
+          dotnet pack src/VSMCP.Server/VSMCP.Server.csproj `
+            -c Release --no-build -o artifacts `
+            -p:PackageVersion=${{ steps.version.outputs.version }} `
+            -nologo
+
+      - name: Stage artifacts
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path release-artifacts | Out-Null
+          Copy-Item src/VSMCP.Vsix/bin/Release/*.vsix release-artifacts/
+          Copy-Item artifacts/*.nupkg release-artifacts/
+          Get-ChildItem release-artifacts | Format-Table -AutoSize
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          generate_release_notes: true
+          files: |
+            release-artifacts/*.vsix
+            release-artifacts/*.nupkg
+
+      # ---- Optional publishing steps. Both are no-ops when the secret is absent. ----
+
+      - name: Publish to NuGet
+        if: env.NUGET_API_KEY != ''
+        shell: pwsh
+        run: |
+          $pkg = Get-ChildItem artifacts/*.nupkg | Select-Object -First 1
+          dotnet nuget push $pkg.FullName `
+            --api-key $env:NUGET_API_KEY `
+            --source https://api.nuget.org/v3/index.json `
+            --skip-duplicate
+
+      - name: Publish to Visual Studio Marketplace
+        if: env.VSCE_PAT != ''
+        shell: pwsh
+        run: |
+          $vsix = Get-ChildItem src/VSMCP.Vsix/bin/Release/*.vsix | Select-Object -First 1
+          $manifest = "release/publishManifest.json"
+          if (-not (Test-Path $manifest))
+          {
+            Write-Host "::warning::$manifest not found — skipping Marketplace publish."
+            exit 0
+          }
+          $publisher = Get-ChildItem -Path `
+            "C:\Program Files\Microsoft Visual Studio\2022\*\VSSDK\VisualStudioIntegration\Tools\Bin\VsixPublisher.exe" `
+            -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $publisher)
+          {
+            Write-Host "::error::VsixPublisher.exe not found on runner; install the VS SDK."
+            exit 1
+          }
+          & $publisher.FullName publish `
+            -payload $vsix.FullName `
+            -publishManifest $manifest `
+            -personalAccessToken $env:VSCE_PAT

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,49 @@
+# Release pipeline
+
+Pushing a tag of the form `v*` (e.g. `v0.2.0`) triggers `.github/workflows/release.yml`,
+which builds everything in `Release` config, creates a GitHub Release, and attaches:
+
+- `VSMCP.Vsix-<version>.vsix` — Visual Studio 2022 extension.
+- `VSMCP.Server.<version>.nupkg` — stdio MCP bridge, installable as a `dotnet tool`.
+
+## Cutting a release
+
+```bash
+# Bump versions as needed, commit, then:
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+The workflow resolves the version from the tag (`v0.2.0` → `0.2.0`) and passes it to
+MSBuild and `dotnet pack`. No manual version bumps in csproj/vsixmanifest are required
+if the projects pick up `-p:Version` / `-p:PackageVersion`.
+
+## Optional publishing
+
+The workflow conditionally publishes to NuGet and the VS Marketplace if the
+corresponding repository secrets are set. Without them the GitHub Release is still
+produced — only the public-registry push is skipped.
+
+| Secret | Purpose | How to obtain |
+| --- | --- | --- |
+| `NUGET_API_KEY` | Push `VSMCP.Server.nupkg` to [nuget.org](https://www.nuget.org/). | [nuget.org account settings → API Keys](https://www.nuget.org/account/apikeys). Scope it to the `VSMCP.Server` package id. |
+| `VSCE_PAT` | Push the `.vsix` to the [Visual Studio Marketplace](https://marketplace.visualstudio.com/). | [Azure DevOps PAT](https://dev.azure.com/) with `Marketplace → Publish` scope, associated with the `pauliver` publisher. |
+
+Add them under **Settings → Secrets and variables → Actions**.
+
+### Marketplace manifest
+
+`release/publishManifest.json` drives the Marketplace metadata. Update the `publisher`
+field if you fork this project. `release/overview.md` is the short description shown on
+the Marketplace listing.
+
+## Code signing — deferred
+
+The VSIX and the `.nupkg` are currently unsigned. Once we have an Authenticode / code-signing
+certificate, add these steps to `release.yml`:
+
+- **VSIX**: run `VsixSignTool.exe sign /f <cert.pfx> /p <password> /tr http://timestamp.digicert.com /td sha256 /fd sha256 <path-to-vsix>` before upload.
+- **NuGet**: run `dotnet nuget sign <nupkg> --certificate-path <cert.pfx> --certificate-password <password> --timestamper http://timestamp.digicert.com` before push.
+
+Store cert material in secrets (`CODESIGN_PFX_B64`, `CODESIGN_PFX_PASSWORD`) and decode
+in a step that runs before the sign step.

--- a/release/overview.md
+++ b/release/overview.md
@@ -1,0 +1,5 @@
+# VSMCP
+
+MCP server for Visual Studio 2022 — gives AI assistants the full power of the VS debugger,
+build pipeline, and diagnostics tooling (not just code editing). See
+[github.com/pauliver/VSMCP](https://github.com/pauliver/VSMCP) for docs, tool catalog, and setup.

--- a/release/publishManifest.json
+++ b/release/publishManifest.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json.schemastore.org/vsix-publish",
+  "categories": [
+    "Debugging",
+    "Developer Tools"
+  ],
+  "identity": {
+    "internalName": "VSMCP"
+  },
+  "overview": "release/overview.md",
+  "priceCategory": "free",
+  "publisher": "pauliver",
+  "private": false,
+  "qna": true,
+  "repo": "https://github.com/pauliver/VSMCP"
+}


### PR DESCRIPTION
## Summary
- `.github/workflows/release.yml` fires on `v*` tags (and supports `workflow_dispatch` on existing tags). Builds in Release, packs the `dotnet tool` nupkg, and creates a GitHub Release with the `.vsix` and `.nupkg` attached.
- NuGet publish runs only when `NUGET_API_KEY` is set. Marketplace publish (via `VsixPublisher.exe`) runs only when `VSCE_PAT` is set. Neither is required — the GitHub Release still goes out.
- Version is resolved from the tag (`v0.2.0` → `0.2.0`) and passed to MSBuild / `dotnet pack`.
- `release/` folder contains the Marketplace manifest, overview, and maintainer docs covering secret setup and the deferred code-signing plan.

## Test plan
- [ ] Push a throwaway tag (e.g. `v0.0.0-dryrun`) and confirm the workflow builds and creates a draft GH Release with both artifacts.
- [ ] Confirm the workflow runs to completion when no secrets are set (publish steps should be skipped).
- [ ] Once secrets exist, repeat on a real tag and verify NuGet and Marketplace listings pick up the new version.
- [ ] Delete the dryrun tag + release after validation.

## Deferred
- Code signing (VSIX + nupkg) — requires a cert we don't have yet. Process documented in `release/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)