### PR TITLE
Tool window: live pipe-host activity panel

### DIFF
--- a/src/VSMCP.Vsix/HostActivity.cs
+++ b/src/VSMCP.Vsix/HostActivity.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// Observable state of the pipe host: how many clients are attached, when activity
+/// last happened, and a bounded ring of recent RPC calls. Purely in-memory; one
+/// instance per <see cref="VSMCPPackage"/>. Thread-safe for the writer path
+/// (<see cref="PipeHost"/>) and for snapshot reads from the UI.
+/// </summary>
+internal sealed class HostActivity
+{
+    private const int RecentCapacity = 50;
+    private readonly object _gate = new();
+    private readonly LinkedList<RpcEntry> _recent = new();
+    private int _clientCount;
+    private long _rpcCount;
+    private long _rpcErrorCount;
+    private DateTime _lastActivityUtc;
+    private DateTime _startedUtc = DateTime.UtcNow;
+    private string? _lastError;
+
+    public string PipeName { get; set; } = "";
+
+    public event EventHandler? Changed;
+
+    public void OnConnected()
+    {
+        lock (_gate)
+        {
+            _clientCount++;
+            _lastActivityUtc = DateTime.UtcNow;
+        }
+        Raise();
+    }
+
+    public void OnDisconnected()
+    {
+        lock (_gate)
+        {
+            if (_clientCount > 0) _clientCount--;
+            _lastActivityUtc = DateTime.UtcNow;
+        }
+        Raise();
+    }
+
+    public void OnRpcCompleted(string method, double elapsedMs, string? error)
+    {
+        lock (_gate)
+        {
+            _rpcCount++;
+            _lastActivityUtc = DateTime.UtcNow;
+            if (!string.IsNullOrEmpty(error))
+            {
+                _rpcErrorCount++;
+                _lastError = $"{method}: {error}";
+            }
+            _recent.AddFirst(new RpcEntry(DateTime.UtcNow, method, elapsedMs, error));
+            while (_recent.Count > RecentCapacity) _recent.RemoveLast();
+        }
+        Raise();
+    }
+
+    public Snapshot GetSnapshot()
+    {
+        lock (_gate)
+        {
+            var entries = new RpcEntry[_recent.Count];
+            int i = 0;
+            foreach (var e in _recent) entries[i++] = e;
+            return new Snapshot(
+                PipeName,
+                _clientCount,
+                _rpcCount,
+                _rpcErrorCount,
+                _lastActivityUtc,
+                _startedUtc,
+                _lastError,
+                entries);
+        }
+    }
+
+    private void Raise()
+    {
+        try { Changed?.Invoke(this, EventArgs.Empty); } catch { }
+    }
+
+    internal readonly struct RpcEntry
+    {
+        public RpcEntry(DateTime whenUtc, string method, double elapsedMs, string? error)
+        {
+            WhenUtc = whenUtc;
+            Method = method;
+            ElapsedMs = elapsedMs;
+            Error = error;
+        }
+
+        public DateTime WhenUtc { get; }
+        public string Method { get; }
+        public double ElapsedMs { get; }
+        public string? Error { get; }
+    }
+
+    internal sealed class Snapshot
+    {
+        public Snapshot(string pipeName, int clientCount, long rpcCount, long rpcErrorCount,
+                        DateTime lastActivityUtc, DateTime startedUtc, string? lastError,
+                        IReadOnlyList<RpcEntry> recent)
+        {
+            PipeName = pipeName;
+            ClientCount = clientCount;
+            RpcCount = rpcCount;
+            RpcErrorCount = rpcErrorCount;
+            LastActivityUtc = lastActivityUtc;
+            StartedUtc = startedUtc;
+            LastError = lastError;
+            Recent = recent;
+        }
+
+        public string PipeName { get; }
+        public int ClientCount { get; }
+        public long RpcCount { get; }
+        public long RpcErrorCount { get; }
+        public DateTime LastActivityUtc { get; }
+        public DateTime StartedUtc { get; }
+        public string? LastError { get; }
+        public IReadOnlyList<RpcEntry> Recent { get; }
+    }
+}

--- a/src/VSMCP.Vsix/PipeHost.cs
+++ b/src/VSMCP.Vsix/PipeHost.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
 using System.Security.AccessControl;
@@ -20,15 +21,20 @@ internal sealed class PipeHost : IDisposable
 {
     private readonly VSMCPPackage _package;
     private readonly JoinableTaskFactory _jtf;
+    private readonly HostActivity _activity;
     private readonly CancellationTokenSource _cts = new();
     private readonly string _pipeName;
 
-    public PipeHost(VSMCPPackage package, JoinableTaskFactory jtf)
+    public PipeHost(VSMCPPackage package, JoinableTaskFactory jtf, HostActivity activity)
     {
         _package = package;
         _jtf = jtf;
+        _activity = activity;
         _pipeName = PipeNaming.ForCurrentProcess();
+        _activity.PipeName = _pipeName;
     }
+
+    public string PipeName => _pipeName;
 
     public void Start()
     {
@@ -45,11 +51,17 @@ internal sealed class PipeHost : IDisposable
                 server = CreateServerStream(_pipeName);
                 await server.WaitForConnectionAsync(ct).ConfigureAwait(false);
 
+                _activity.OnConnected();
+                var capturedStream = server;
                 var target = new RpcTarget(_package, _jtf);
                 var rpc = AttachWithAutoFocus(server, target);
                 // Each connection owns its own stream; don't await Completion here — we want to
                 // accept the next connection immediately. The rpc/stream dispose together.
-                _ = rpc.Completion.ContinueWith(_ => server.Dispose(), TaskScheduler.Default);
+                _ = rpc.Completion.ContinueWith(_ =>
+                {
+                    _activity.OnDisconnected();
+                    capturedStream.Dispose();
+                }, TaskScheduler.Default);
                 server = null; // ownership transferred
             }
             catch (OperationCanceledException) { return; }
@@ -89,7 +101,7 @@ internal sealed class PipeHost : IDisposable
     private JsonRpc AttachWithAutoFocus(Stream stream, RpcTarget target)
     {
         var handler = new HeaderDelimitedMessageHandler(stream);
-        var rpc = new AutoFocusJsonRpc(handler, _package, _jtf, target);
+        var rpc = new AutoFocusJsonRpc(handler, _package, _jtf, target, _activity);
         rpc.AddLocalRpcTarget(target);
         rpc.StartListening();
         return rpc;
@@ -105,23 +117,37 @@ internal sealed class PipeHost : IDisposable
         private readonly VSMCPPackage _package;
         private readonly JoinableTaskFactory _jtf;
         private readonly RpcTarget _target;
+        private readonly HostActivity _activity;
 
-        public AutoFocusJsonRpc(IJsonRpcMessageHandler handler, VSMCPPackage package, JoinableTaskFactory jtf, RpcTarget target)
+        public AutoFocusJsonRpc(IJsonRpcMessageHandler handler, VSMCPPackage package, JoinableTaskFactory jtf, RpcTarget target, HostActivity activity)
             : base(handler)
         {
             _package = package;
             _jtf = jtf;
             _target = target;
+            _activity = activity;
         }
 
         protected override async ValueTask<JsonRpcMessage> DispatchRequestAsync(JsonRpcRequest request, TargetMethod targetMethod, CancellationToken cancellationToken)
         {
+            var sw = Stopwatch.StartNew();
+            string? error = null;
             try
             {
-                return await base.DispatchRequestAsync(request, targetMethod, cancellationToken).ConfigureAwait(false);
+                var result = await base.DispatchRequestAsync(request, targetMethod, cancellationToken).ConfigureAwait(false);
+                if (result is JsonRpcError err) error = err.Error?.Message ?? "error";
+                return result;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                throw;
             }
             finally
             {
+                sw.Stop();
+                try { _activity.OnRpcCompleted(request?.Method ?? "?", sw.Elapsed.TotalMilliseconds, error); } catch { }
+
                 if (_target.AutoFocusEnabled && !SkipFocus(request?.Method))
                 {
                     try { await FocusHelper.ActivateAsync(_package, _jtf, cancellationToken).ConfigureAwait(false); } catch { }

--- a/src/VSMCP.Vsix/RpcTarget.cs
+++ b/src/VSMCP.Vsix/RpcTarget.cs
@@ -22,8 +22,10 @@ internal sealed partial class RpcTarget : IVsmcpRpc
     /// <summary>
     /// Teaching mode: when true, the pipe host raises the VS main window to the foreground
     /// after every dispatched RPC so a human observer always sees the IDE react. Default on.
+    /// Seeded from <see cref="VsmcpGlobalDefaults.AutoFocusDefault"/> (which the tool window
+    /// updates) so new connections honor the user's most recent UI choice.
     /// </summary>
-    public bool AutoFocusEnabled { get; set; } = true;
+    public bool AutoFocusEnabled { get; set; } = VsmcpGlobalDefaults.AutoFocusDefault;
 
     public RpcTarget(VSMCPPackage package, JoinableTaskFactory jtf)
     {

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -53,9 +53,15 @@
 
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Design" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
+    <Reference Include="System.Xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -76,6 +82,10 @@
     <Compile Include="RpcTarget.Code.cs" />
     <Compile Include="RpcTarget.Focus.cs" />
     <Compile Include="FocusHelper.cs" />
+    <Compile Include="HostActivity.cs" />
+    <Compile Include="VsmcpToolWindow.cs" />
+    <Compile Include="VsmcpToolWindowControl.cs" />
+    <Compile Include="VsmcpCommands.cs" />
     <Compile Include="ModuleTracker.cs" />
     <Compile Include="BuildCoordinator.cs" />
     <Compile Include="VsHelpers.cs" />
@@ -85,6 +95,9 @@
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
+    <VSCTCompile Include="VSMCPPackage.vsct">
+      <ResourceName>Menus.ctmenu</ResourceName>
+    </VSCTCompile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VSMCP.Vsix/VSMCPPackage.cs
+++ b/src/VSMCP.Vsix/VSMCPPackage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.VisualStudio.Shell;
@@ -11,22 +12,30 @@ namespace VSMCP.Vsix;
 [Guid(PackageGuidString)]
 [ProvideAutoLoad(Microsoft.VisualStudio.VSConstants.UICONTEXT.NoSolution_string, PackageAutoLoadFlags.BackgroundLoad)]
 [ProvideAutoLoad(Microsoft.VisualStudio.VSConstants.UICONTEXT.SolutionExists_string, PackageAutoLoadFlags.BackgroundLoad)]
+[ProvideMenuResource("Menus.ctmenu", 1)]
+[ProvideToolWindow(typeof(VsmcpToolWindow), Style = VsDockStyle.Tabbed, Window = EnvDTE.Constants.vsWindowKindOutput)]
 public sealed class VSMCPPackage : AsyncPackage
 {
     public const string PackageGuidString = "7e0b4e3e-0000-0000-0000-000000000001";
 
     private PipeHost? _pipeHost;
     private ModuleTracker? _moduleTracker;
+    private HostActivity? _activity;
 
     internal ModuleTracker? Modules => _moduleTracker;
+    internal HostActivity Activity => _activity ??= new HostActivity();
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
+        _activity = new HostActivity();
+
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
         var vsDebugger = await GetServiceAsync(typeof(SVsShellDebugger)) as IVsDebugger;
         _moduleTracker = new ModuleTracker(vsDebugger);
-        _pipeHost = new PipeHost(this, JoinableTaskFactory);
+        _pipeHost = new PipeHost(this, JoinableTaskFactory, _activity);
         _pipeHost.Start();
+
+        await VsmcpCommands.InitializeAsync(this);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/VSMCP.Vsix/VSMCPPackage.vsct
+++ b/src/VSMCP.Vsix/VSMCPPackage.vsct
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CommandTable xmlns="http://schemas.microsoft.com/VisualStudio/2005-10-18/CommandTable" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <Extern href="stdidcmd.h" />
+  <Extern href="vsshlids.h" />
+
+  <Commands package="guidVSMCPPackage">
+    <Groups>
+      <Group guid="guidVSMCPCommandSet" id="VsmcpToolsGroup" priority="0x0600">
+        <Parent guid="guidSHLMainMenu" id="IDM_VS_MENU_TOOLS" />
+      </Group>
+    </Groups>
+
+    <Buttons>
+      <Button guid="guidVSMCPCommandSet" id="cmdidShowToolWindow" priority="0x0100" type="Button">
+        <Parent guid="guidVSMCPCommandSet" id="VsmcpToolsGroup" />
+        <Strings>
+          <ButtonText>VSMCP Panel</ButtonText>
+          <CommandName>VSMCP Panel</CommandName>
+        </Strings>
+      </Button>
+    </Buttons>
+  </Commands>
+
+  <Symbols>
+    <GuidSymbol name="guidVSMCPPackage" value="{7e0b4e3e-0000-0000-0000-000000000001}" />
+
+    <GuidSymbol name="guidVSMCPCommandSet" value="{7e0b4e3e-0000-0000-0000-000000000020}">
+      <IDSymbol name="VsmcpToolsGroup" value="0x1020" />
+      <IDSymbol name="cmdidShowToolWindow" value="0x0100" />
+    </GuidSymbol>
+  </Symbols>
+</CommandTable>

--- a/src/VSMCP.Vsix/VsmcpCommands.cs
+++ b/src/VSMCP.Vsix/VsmcpCommands.cs
@@ -1,0 +1,48 @@
+using System;
+using System.ComponentModel.Design;
+using System.Threading;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// Registers the <c>Tools → VSMCP Panel</c> menu entry that surfaces <see cref="VsmcpToolWindow"/>.
+/// </summary>
+internal static class VsmcpCommands
+{
+    /// <summary>Command set GUID — referenced from the .vsct.</summary>
+    public static readonly Guid CommandSet = new Guid("7e0b4e3e-0000-0000-0000-000000000020");
+
+    /// <summary>Command id for "VSMCP Panel" — matches the .vsct.</summary>
+    public const int ShowToolWindowCommandId = 0x0100;
+
+    public static async Task InitializeAsync(AsyncPackage package)
+    {
+        await package.JoinableTaskFactory.SwitchToMainThreadAsync();
+        var mcs = await package.GetServiceAsync(typeof(IMenuCommandService)) as OleMenuCommandService;
+        if (mcs is null) return;
+
+        var id = new CommandID(CommandSet, ShowToolWindowCommandId);
+        var cmd = new MenuCommand((_, __) => ShowWindow(package), id);
+        mcs.AddCommand(cmd);
+    }
+
+    private static void ShowWindow(AsyncPackage package)
+    {
+        package.JoinableTaskFactory.RunAsync(async () =>
+        {
+            await package.JoinableTaskFactory.SwitchToMainThreadAsync();
+            var window = await package.ShowToolWindowAsync(
+                typeof(VsmcpToolWindow),
+                id: 0,
+                create: true,
+                cancellationToken: CancellationToken.None);
+            if (window?.Frame is IVsWindowFrame frame)
+            {
+                Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(frame.Show());
+            }
+        });
+    }
+}

--- a/src/VSMCP.Vsix/VsmcpToolWindow.cs
+++ b/src/VSMCP.Vsix/VsmcpToolWindow.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// "VSMCP" tool window — View → Other Windows → VSMCP (or Tools → VSMCP Panel).
+/// Shows live pipe activity so an observer can see what the AI just did.
+/// </summary>
+[Guid(WindowGuidString)]
+public sealed class VsmcpToolWindow : ToolWindowPane
+{
+    public const string WindowGuidString = "7e0b4e3e-0000-0000-0000-000000000010";
+
+    public VsmcpToolWindow() : base(null)
+    {
+        Caption = "VSMCP";
+    }
+
+    protected override void Initialize()
+    {
+        base.Initialize();
+        if (Package is VSMCPPackage pkg)
+        {
+            Content = new VsmcpToolWindowControl(pkg.Activity);
+        }
+        else
+        {
+            Content = new VsmcpToolWindowControl(new HostActivity());
+        }
+    }
+}

--- a/src/VSMCP.Vsix/VsmcpToolWindowControl.cs
+++ b/src/VSMCP.Vsix/VsmcpToolWindowControl.cs
@@ -1,0 +1,286 @@
+using System;
+using System.Diagnostics;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using System.Windows.Threading;
+using IoPath = System.IO.Path;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// WPF surface for the VSMCP tool window. No XAML — built in code so the VSIX
+/// project (classic csproj) doesn't need Page/Markup build actions wired up.
+/// Binds to <see cref="HostActivity"/> and repaints on Changed plus a 1s timer
+/// (the timer keeps the "N seconds ago" readout live when nothing else happens).
+/// </summary>
+internal sealed class VsmcpToolWindowControl : UserControl
+{
+    private readonly HostActivity _activity;
+    private readonly DispatcherTimer _tick;
+
+    private readonly Ellipse _statusDot;
+    private readonly TextBlock _statusText;
+    private readonly TextBlock _pipeName;
+    private readonly TextBlock _lastActivity;
+    private readonly TextBlock _counts;
+    private readonly TextBlock _lastError;
+    private readonly CheckBox _autoFocus;
+    private readonly ListBox _recent;
+
+    public VsmcpToolWindowControl(HostActivity activity)
+    {
+        _activity = activity;
+        Padding = new Thickness(8);
+        Background = SystemColors.WindowBrush;
+
+        var root = new DockPanel { LastChildFill = true };
+
+        // --- Header: status dot + text ---
+        var header = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 0, 0, 8) };
+        _statusDot = new Ellipse
+        {
+            Width = 12,
+            Height = 12,
+            Fill = Brushes.Gray,
+            Margin = new Thickness(0, 2, 6, 0),
+        };
+        _statusText = new TextBlock
+        {
+            FontWeight = FontWeights.Bold,
+            FontSize = 14,
+            VerticalAlignment = VerticalAlignment.Center,
+        };
+        header.Children.Add(_statusDot);
+        header.Children.Add(_statusText);
+        DockPanel.SetDock(header, Dock.Top);
+        root.Children.Add(header);
+
+        // --- Details ---
+        var details = new StackPanel { Margin = new Thickness(0, 0, 0, 8) };
+        _pipeName = AddRow(details, "Pipe:", out var pipePanel);
+        var copyBtn = new Button { Content = "Copy", Margin = new Thickness(8, 0, 0, 0), Padding = new Thickness(6, 0, 6, 0) };
+        copyBtn.Click += (_, __) =>
+        {
+            try { Clipboard.SetText(_activity.PipeName); } catch { }
+        };
+        pipePanel.Children.Add(copyBtn);
+
+        _lastActivity = AddRow(details, "Last activity:");
+        _counts = AddRow(details, "RPCs:");
+        _lastError = AddRow(details, "Last error:");
+        _lastError.Foreground = Brushes.Firebrick;
+
+        _autoFocus = new CheckBox
+        {
+            Content = "Auto-focus VS after each RPC (teaching mode)",
+            Margin = new Thickness(0, 4, 0, 0),
+            IsChecked = true,
+        };
+        _autoFocus.Checked += (_, __) => ApplyAutoFocus(true);
+        _autoFocus.Unchecked += (_, __) => ApplyAutoFocus(false);
+        details.Children.Add(_autoFocus);
+
+        var logsBtn = new Button
+        {
+            Content = "Open logs folder",
+            Margin = new Thickness(0, 6, 0, 0),
+            Padding = new Thickness(6, 2, 6, 2),
+            HorizontalAlignment = HorizontalAlignment.Left,
+        };
+        logsBtn.Click += (_, __) => OpenLogsFolder();
+        details.Children.Add(logsBtn);
+
+        DockPanel.SetDock(details, Dock.Top);
+        root.Children.Add(details);
+
+        // --- Recent RPCs ---
+        var recentHeader = new TextBlock
+        {
+            Text = "Recent RPCs",
+            FontWeight = FontWeights.Bold,
+            Margin = new Thickness(0, 4, 0, 4),
+        };
+        DockPanel.SetDock(recentHeader, Dock.Top);
+        root.Children.Add(recentHeader);
+
+        _recent = new ListBox
+        {
+            BorderThickness = new Thickness(1),
+            BorderBrush = SystemColors.ActiveBorderBrush,
+            FontFamily = new FontFamily("Cascadia Mono, Consolas, Courier New"),
+            FontSize = 12,
+        };
+        root.Children.Add(_recent);
+
+        Content = root;
+
+        _activity.Changed += OnActivityChanged;
+
+        _tick = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromSeconds(1),
+        };
+        _tick.Tick += (_, __) => Refresh();
+        _tick.Start();
+
+        Unloaded += (_, __) =>
+        {
+            _tick.Stop();
+            _activity.Changed -= OnActivityChanged;
+        };
+
+        Refresh();
+    }
+
+    private static TextBlock AddRow(StackPanel panel, string label)
+        => AddRow(panel, label, out _);
+
+    private static TextBlock AddRow(StackPanel panel, string label, out StackPanel row)
+    {
+        row = new StackPanel { Orientation = Orientation.Horizontal, Margin = new Thickness(0, 2, 0, 2) };
+        row.Children.Add(new TextBlock
+        {
+            Text = label,
+            Width = 100,
+            Foreground = Brushes.Gray,
+        });
+        var value = new TextBlock { Text = "" };
+        row.Children.Add(value);
+        panel.Children.Add(row);
+        return value;
+    }
+
+    private void ApplyAutoFocus(bool enabled)
+    {
+        // Fire-and-forget: the checkbox is authoritative, but we only have access
+        // to the package via RpcTarget on demand. Walk up through the package.
+        try
+        {
+            if (FindPackage() is { } pkg)
+            {
+                // Cheap: ask any future RpcTarget via a shared flag. For now we just
+                // mirror onto a static toggle that new RpcTargets pick up at ctor time.
+                VsmcpGlobalDefaults.AutoFocusDefault = enabled;
+            }
+        }
+        catch { }
+    }
+
+    private VSMCPPackage? FindPackage()
+    {
+        // The control's Tag is not set; walk via the Package service if possible.
+        // This path runs on the UI thread so GetGlobalService is fine.
+        try
+        {
+            return Microsoft.VisualStudio.Shell.Package.GetGlobalService(typeof(VSMCPPackage)) as VSMCPPackage;
+        }
+        catch { return null; }
+    }
+
+    private void OnActivityChanged(object? sender, EventArgs e)
+    {
+        if (!Dispatcher.CheckAccess())
+        {
+            Dispatcher.BeginInvoke(new Action(Refresh));
+            return;
+        }
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        var snap = _activity.GetSnapshot();
+
+        _pipeName.Text = string.IsNullOrEmpty(snap.PipeName) ? "(not started)" : snap.PipeName;
+
+        var age = snap.LastActivityUtc == default
+            ? "never"
+            : FormatAge(DateTime.UtcNow - snap.LastActivityUtc);
+        _lastActivity.Text = age;
+        _counts.Text = $"{snap.RpcCount} total, {snap.RpcErrorCount} errors";
+        _lastError.Text = snap.LastError ?? "—";
+
+        // Traffic-light: green connected & recent, yellow connected but idle >30s,
+        // red error in last 5s, gray never connected.
+        var idleSeconds = snap.LastActivityUtc == default ? double.MaxValue : (DateTime.UtcNow - snap.LastActivityUtc).TotalSeconds;
+        if (snap.ClientCount > 0 && idleSeconds < 30)
+        {
+            _statusDot.Fill = Brushes.LimeGreen;
+            _statusText.Text = $"Connected ({snap.ClientCount} client{(snap.ClientCount == 1 ? "" : "s")})";
+        }
+        else if (snap.ClientCount > 0)
+        {
+            _statusDot.Fill = Brushes.Gold;
+            _statusText.Text = $"Connected, idle {FormatAge(TimeSpan.FromSeconds(idleSeconds))}";
+        }
+        else if (snap.RpcErrorCount > 0 && idleSeconds < 5)
+        {
+            _statusDot.Fill = Brushes.IndianRed;
+            _statusText.Text = "Recent error";
+        }
+        else if (snap.RpcCount > 0)
+        {
+            _statusDot.Fill = Brushes.Gray;
+            _statusText.Text = "Disconnected (idle)";
+        }
+        else
+        {
+            _statusDot.Fill = Brushes.LightGray;
+            _statusText.Text = "Waiting for client";
+        }
+
+        // Rebuild recent list (small N, simple refresh is fine).
+        _recent.Items.Clear();
+        foreach (var e in snap.Recent)
+        {
+            var local = e.WhenUtc.ToLocalTime().ToString("HH:mm:ss");
+            var line = string.IsNullOrEmpty(e.Error)
+                ? $"{local}  {e.ElapsedMs,7:F1} ms  {e.Method}"
+                : $"{local}  {e.ElapsedMs,7:F1} ms  {e.Method}   !! {e.Error}";
+            var item = new ListBoxItem
+            {
+                Content = line,
+                Foreground = string.IsNullOrEmpty(e.Error) ? Brushes.Black : Brushes.Firebrick,
+            };
+            _recent.Items.Add(item);
+        }
+    }
+
+    private static string FormatAge(TimeSpan ts)
+    {
+        if (ts.TotalSeconds < 0) ts = TimeSpan.Zero;
+        if (ts.TotalSeconds < 1) return "just now";
+        if (ts.TotalSeconds < 60) return $"{(int)ts.TotalSeconds}s ago";
+        if (ts.TotalMinutes < 60) return $"{(int)ts.TotalMinutes}m {ts.Seconds}s ago";
+        return $"{(int)ts.TotalHours}h {ts.Minutes}m ago";
+    }
+
+    private void OpenLogsFolder()
+    {
+        try
+        {
+            var dir = IoPath.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "VSMCP", "logs");
+            System.IO.Directory.CreateDirectory(dir);
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = dir,
+                UseShellExecute = true,
+            });
+        }
+        catch { }
+    }
+}
+
+/// <summary>
+/// Global toggle the tool window flips when the auto-focus checkbox changes.
+/// <see cref="RpcTarget"/> picks this up at construction time so newly-attached
+/// clients respect the current UI setting. Existing clients are not reset.
+/// </summary>
+internal static class VsmcpGlobalDefaults
+{
+    public static bool AutoFocusDefault { get; set; } = true;
+}


### PR DESCRIPTION
## Summary
- Adds `Tools → VSMCP Panel` tool window showing live pipe host status
- Traffic-light dot (green/yellow/red/gray), pipe name w/ copy, last activity age, RPC totals, last error, recent-RPC log, auto-focus toggle, open-logs button
- `HostActivity` observable + ring buffer wired from `PipeHost` (connect/disconnect + per-RPC elapsed/error)
- WPF built in code (no XAML) to avoid Page/Markup build actions in the classic VSIX csproj

Refs #33 — status bar item deferred to a follow-up.

## Test plan
- [ ] F5 into experimental hive, open `Tools → VSMCP Panel`
- [ ] Confirm pipe name shown, status goes green when VSMCP.Server connects
- [ ] Run a few RPCs, confirm list populates and counts increment
- [ ] Toggle auto-focus checkbox, verify new connections respect the setting
- [ ] Click "Open logs folder", confirm %LOCALAPPDATA%\VSMCP\logs opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)