### PR TITLE
Status bar: live VSMCP connection readout

### DIFF
--- a/src/VSMCP.Vsix/StatusBarReporter.cs
+++ b/src/VSMCP.Vsix/StatusBarReporter.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Windows.Threading;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace VSMCP.Vsix;
+
+/// <summary>
+/// Mirrors <see cref="HostActivity"/> onto the VS main status bar so a live
+/// "VSMCP: connected (1) · 42 RPCs" readout is visible without opening the
+/// tool window. Uses <see cref="IVsStatusbar.SetText"/>; other components can
+/// overwrite it, so we reassert every 2s via a dispatcher tick.
+/// </summary>
+internal sealed class StatusBarReporter : IDisposable
+{
+    private readonly HostActivity _activity;
+    private readonly IVsStatusbar _bar;
+    private readonly JoinableTaskFactory _jtf;
+    private readonly DispatcherTimer _tick;
+    private bool _disposed;
+
+    public StatusBarReporter(HostActivity activity, IVsStatusbar bar, JoinableTaskFactory jtf)
+    {
+        _activity = activity;
+        _bar = bar;
+        _jtf = jtf;
+
+        _activity.Changed += OnChanged;
+
+        _tick = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            Interval = TimeSpan.FromSeconds(2),
+        };
+        _tick.Tick += (_, __) => Push();
+        _tick.Start();
+
+        Push();
+    }
+
+    private void OnChanged(object? sender, EventArgs e)
+    {
+        // Changed fires from the pipe host thread; marshal to UI for the status bar.
+        _jtf.RunAsync(async () =>
+        {
+            await _jtf.SwitchToMainThreadAsync();
+            Push();
+        }).Task.Forget();
+    }
+
+    private void Push()
+    {
+        if (_disposed) return;
+        try
+        {
+            _bar.IsFrozen(out var frozen);
+            if (frozen != 0) return;
+
+            var snap = _activity.GetSnapshot();
+            string text;
+            if (snap.ClientCount > 0)
+            {
+                var idle = snap.LastActivityUtc == default
+                    ? ""
+                    : $" · {(int)(DateTime.UtcNow - snap.LastActivityUtc).TotalSeconds}s idle";
+                text = $"VSMCP: connected ({snap.ClientCount}) · {snap.RpcCount} RPCs" +
+                       (snap.RpcErrorCount > 0 ? $" · {snap.RpcErrorCount} err" : "") +
+                       idle;
+            }
+            else if (snap.RpcCount > 0)
+            {
+                text = $"VSMCP: idle · {snap.RpcCount} RPCs";
+            }
+            else
+            {
+                text = "VSMCP: waiting for client";
+            }
+
+            _bar.SetText(text);
+        }
+        catch { }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _tick.Stop();
+        _activity.Changed -= OnChanged;
+        try { _bar.SetText(""); } catch { }
+    }
+}

--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -83,6 +83,7 @@
     <Compile Include="RpcTarget.Focus.cs" />
     <Compile Include="FocusHelper.cs" />
     <Compile Include="HostActivity.cs" />
+    <Compile Include="StatusBarReporter.cs" />
     <Compile Include="VsmcpToolWindow.cs" />
     <Compile Include="VsmcpToolWindowControl.cs" />
     <Compile Include="VsmcpCommands.cs" />

--- a/src/VSMCP.Vsix/VSMCPPackage.cs
+++ b/src/VSMCP.Vsix/VSMCPPackage.cs
@@ -21,6 +21,7 @@ public sealed class VSMCPPackage : AsyncPackage
     private PipeHost? _pipeHost;
     private ModuleTracker? _moduleTracker;
     private HostActivity? _activity;
+    private StatusBarReporter? _statusBar;
 
     internal ModuleTracker? Modules => _moduleTracker;
     internal HostActivity Activity => _activity ??= new HostActivity();
@@ -35,6 +36,11 @@ public sealed class VSMCPPackage : AsyncPackage
         _pipeHost = new PipeHost(this, JoinableTaskFactory, _activity);
         _pipeHost.Start();
 
+        if (await GetServiceAsync(typeof(SVsStatusbar)) is IVsStatusbar bar)
+        {
+            _statusBar = new StatusBarReporter(_activity, bar, JoinableTaskFactory);
+        }
+
         await VsmcpCommands.InitializeAsync(this);
     }
 
@@ -42,6 +48,8 @@ public sealed class VSMCPPackage : AsyncPackage
     {
         if (disposing)
         {
+            _statusBar?.Dispose();
+            _statusBar = null;
             _pipeHost?.Dispose();
             _pipeHost = null;
             _moduleTracker?.Dispose();


### PR DESCRIPTION
## Summary
- Mirrors \`HostActivity\` onto the VS main status bar
- Shows \`VSMCP: connected (N) · M RPCs · Ks idle\` when a client is attached; \`VSMCP: idle · M RPCs\` or \`VSMCP: waiting for client\` otherwise
- Refreshes on \`Changed\` and every 2s to survive other components overwriting the status bar text

Closes #33.

## Test plan
- [ ] F5 into experimental hive
- [ ] Confirm status bar shows \"VSMCP: waiting for client\" at idle
- [ ] Connect VSMCP.Server, confirm it flips to \"connected (1)\"
- [ ] Run a few RPCs, confirm RPC count increments
- [ ] Disconnect, confirm returns to idle/waiting state

🤖 Generated with [Claude Code](https://claude.com/claude-code)