### PR TITLE
Include VSMCP.Shared.dll in the VSIX

### DIFF
--- a/src/VSMCP.Vsix/VSMCP.Vsix.csproj
+++ b/src/VSMCP.Vsix/VSMCP.Vsix.csproj
@@ -113,7 +113,8 @@
     <ProjectReference Include="..\VSMCP.Shared\VSMCP.Shared.csproj">
       <Project>{A1111111-1111-1111-1111-111111111111}</Project>
       <Name>VSMCP.Shared</Name>
-      <Private>false</Private>
+      <Private>true</Private>
+      <IncludeInVSIX>true</IncludeInVSIX>
     </ProjectReference>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
VSIX package failed to load with \`SetSite failed for package [VSMCPPackage] HRESULT 0x80070002\` (FILE_NOT_FOUND) after install — the ProjectReference to VSMCP.Shared had \`<Private>false</Private>\`, which kept VSMCP.Shared.dll out of the .vsix container. Package activation needed types from that assembly, couldn't find it, and bailed.

Fix: \`<Private>true</Private>\` + \`<IncludeInVSIX>true</IncludeInVSIX>\`. Verified by extracting the rebuilt .vsix — VSMCP.Shared.dll is now present.

## Test plan
- [x] Rebuild Release, \`unzip\` the .vsix, confirm \`VSMCP.Shared.dll\` is included
- [x] Reinstall into the user's VS 2022 hive (no elevation, no errors)
- [ ] Launch VS 2022, confirm no ActivityLog error and \`Tools → VSMCP Panel\` opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)