### PR TITLE
Fix tool window binding to orphaned HostActivity

### DIFF
--- a/src/VSMCP.Vsix/VSMCPPackage.cs
+++ b/src/VSMCP.Vsix/VSMCPPackage.cs
@@ -18,18 +18,23 @@ public sealed class VSMCPPackage : AsyncPackage
 {
     public const string PackageGuidString = "7e0b4e3e-0000-0000-0000-000000000001";
 
+    public static VSMCPPackage? Instance { get; private set; }
+
     private PipeHost? _pipeHost;
     private ModuleTracker? _moduleTracker;
-    private HostActivity? _activity;
+    private readonly HostActivity _activity = new HostActivity();
     private StatusBarReporter? _statusBar;
 
+    public VSMCPPackage()
+    {
+        Instance = this;
+    }
+
     internal ModuleTracker? Modules => _moduleTracker;
-    internal HostActivity Activity => _activity ??= new HostActivity();
+    internal HostActivity Activity => _activity;
 
     protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
     {
-        _activity = new HostActivity();
-
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
         var vsDebugger = await GetServiceAsync(typeof(SVsShellDebugger)) as IVsDebugger;
         _moduleTracker = new ModuleTracker(vsDebugger);
@@ -54,6 +59,7 @@ public sealed class VSMCPPackage : AsyncPackage
             _pipeHost = null;
             _moduleTracker?.Dispose();
             _moduleTracker = null;
+            if (ReferenceEquals(Instance, this)) Instance = null;
         }
         base.Dispose(disposing);
     }

--- a/src/VSMCP.Vsix/VsmcpToolWindow.cs
+++ b/src/VSMCP.Vsix/VsmcpToolWindow.cs
@@ -21,13 +21,9 @@ public sealed class VsmcpToolWindow : ToolWindowPane
     protected override void Initialize()
     {
         base.Initialize();
-        if (Package is VSMCPPackage pkg)
-        {
-            Content = new VsmcpToolWindowControl(pkg.Activity);
-        }
-        else
-        {
-            Content = new VsmcpToolWindowControl(new HostActivity());
-        }
+        var pkg = (Package as VSMCPPackage) ?? VSMCPPackage.Instance;
+        if (pkg is null)
+            throw new InvalidOperationException("VSMCPPackage instance not available — tool window cannot bind to pipe activity.");
+        Content = new VsmcpToolWindowControl(pkg.Activity);
     }
 }


### PR DESCRIPTION
## Summary
- Tool window appeared empty during live RPC traffic — it was bound to a different `HostActivity` than the one `PipeHost` was updating.
- Root cause: VS restored the persisted tool window on startup, and its `Initialize` ran before `InitializeAsync` assigned `_activity`. The lazy getter created instance A; `InitializeAsync` then replaced it with B and handed B to `PipeHost`. The tool window stayed bound to A forever.
- Fix: eagerly initialize `_activity` at the package's field declaration so exactly one instance exists for the package lifetime. Expose a static `Instance` as a fallback path for the tool window to reach the package even if `ToolWindowPane.Package` is not yet sited.

## Test plan
- [x] Install the rebuilt VSIX in VS 2022 Enterprise
- [x] Open View → Other Windows → VSMCP
- [x] Run `tests/Skills.E2E` with `VSMCP_E2E=1` and confirm the panel reports RPCs and method names in real time (previously stuck at 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)