### PR TITLE
Force tool window onto the VS main UI thread

### DIFF
--- a/src/VSMCP.Vsix/VsmcpToolWindow.cs
+++ b/src/VSMCP.Vsix/VsmcpToolWindow.cs
@@ -24,6 +24,18 @@ public sealed class VsmcpToolWindow : ToolWindowPane
         var pkg = (Package as VSMCPPackage) ?? VSMCPPackage.Instance;
         if (pkg is null)
             throw new InvalidOperationException("VSMCPPackage instance not available — tool window cannot bind to pipe activity.");
-        Content = new VsmcpToolWindowControl(pkg.Activity);
+
+        // Force construction on the VS main UI thread. With an AsyncPackage, Initialize
+        // can run on a pool thread when VS restores a persisted tool window — and the
+        // WPF Control created there ends up with a Dispatcher pointing at that pool
+        // thread, which never pumps. The tool window then appears to be "stuck" even
+        // though HostActivity is being updated (cf. the StatusBarReporter which works
+        // because it uses JTF directly). Marshaling once here guarantees the Control
+        // and its Dispatcher live on the real UI thread.
+        ThreadHelper.JoinableTaskFactory.Run(async () =>
+        {
+            await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
+            Content = new VsmcpToolWindowControl(pkg.Activity, ThreadHelper.JoinableTaskFactory);
+        });
     }
 }

--- a/src/VSMCP.Vsix/VsmcpToolWindowControl.cs
+++ b/src/VSMCP.Vsix/VsmcpToolWindowControl.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Windows.Threading;
+using Microsoft.VisualStudio.Threading;
 using IoPath = System.IO.Path;
 
 namespace VSMCP.Vsix;
@@ -18,6 +19,7 @@ namespace VSMCP.Vsix;
 internal sealed class VsmcpToolWindowControl : UserControl
 {
     private readonly HostActivity _activity;
+    private readonly JoinableTaskFactory _jtf;
     private readonly DispatcherTimer _tick;
 
     private readonly Ellipse _statusDot;
@@ -29,9 +31,10 @@ internal sealed class VsmcpToolWindowControl : UserControl
     private readonly CheckBox _autoFocus;
     private readonly ListBox _recent;
 
-    public VsmcpToolWindowControl(HostActivity activity)
+    public VsmcpToolWindowControl(HostActivity activity, JoinableTaskFactory jtf)
     {
         _activity = activity;
+        _jtf = jtf;
         Padding = new Thickness(8);
         Background = SystemColors.WindowBrush;
 
@@ -181,12 +184,14 @@ internal sealed class VsmcpToolWindowControl : UserControl
 
     private void OnActivityChanged(object? sender, EventArgs e)
     {
-        if (!Dispatcher.CheckAccess())
+        // Changed fires from the pipe host thread. Route through JTF so we always
+        // land on the VS main UI thread, even if this Control's Dispatcher somehow
+        // points elsewhere (e.g., async tool-window restore quirks).
+        _jtf.RunAsync(async () =>
         {
-            Dispatcher.BeginInvoke(new Action(Refresh));
-            return;
-        }
-        Refresh();
+            await _jtf.SwitchToMainThreadAsync();
+            Refresh();
+        }).Task.Forget();
     }
 
     private void Refresh()


### PR DESCRIPTION
## Summary
- Tool window appeared empty during live debug sessions even though HostActivity was being updated (status bar reflected RPC counts in real time).
- Cause: AsyncPackage can run \`VsmcpToolWindow.Initialize()\` on a thread-pool thread when restoring a persisted tool window at VS startup. The WPF Control created there latched onto that thread's Dispatcher, which never pumps — so neither the 1s timer nor the Changed-event BeginInvoke ever fired. The status bar kept working because \`StatusBarReporter\` already marshaled through \`JoinableTaskFactory\`.
- Fix: use \`ThreadHelper.JoinableTaskFactory.Run\` in \`Initialize\` to guarantee Control construction on the VS main UI thread, and route Changed through JTF so even a mis-threaded Control would still land Refresh on the correct thread.

## Test plan
- [x] Rebuild VSIX, swap DLLs, relaunch VS
- [x] Start a debug session, confirm Recent RPCs list populates in real time (previously stayed empty throughout the session)
- [x] Status bar remains consistent with tool window state

🤖 Generated with [Claude Code](https://claude.com/claude-code)