### PR TITLE
Fix build.wait always paying full timeout (#47)

### DIFF
--- a/src/VSMCP.Vsix/BuildCoordinator.cs
+++ b/src/VSMCP.Vsix/BuildCoordinator.cs
@@ -113,6 +113,13 @@ internal sealed class BuildJob : IVsUpdateSolutionEvents2
     public uint AdviseCookie { get; set; }
     public IVsSolutionBuildManager2? BuildManager { get; set; }
 
+    /// <summary>
+    /// Invoked from <see cref="UpdateSolution_Done"/> so the owner (RpcTarget) can
+    /// collect diagnostics, unadvise, and signal <see cref="Completion"/>. Runs on
+    /// the VS UI thread because IVsUpdateSolutionEvents2 fires there.
+    /// </summary>
+    public Action<BuildJob>? OnDone { get; set; }
+
     // -------- IVsUpdateSolutionEvents2 --------
 
     public int UpdateSolution_Begin(ref int pfCancelUpdate) => 0;
@@ -124,7 +131,7 @@ internal sealed class BuildJob : IVsUpdateSolutionEvents2
                   : BuildState.Failed;
         State = final;
         EndedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-        // Coordinator completes the TCS after it collects diagnostics; just record the result here.
+        try { OnDone?.Invoke(this); } catch { }
         return 0;
     }
 

--- a/src/VSMCP.Vsix/RpcTarget.Build.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Build.cs
@@ -45,6 +45,7 @@ internal sealed partial class RpcTarget
             ?? throw new VsmcpException(ErrorCodes.InteropFault, "IVsSolutionBuildManager2 unavailable.");
 
         job.BuildManager = bm;
+        job.OnDone = j => MaybeFinalize(j);
         ErrorHandler.ThrowOnFailure(bm.AdviseUpdateSolutionEvents(job, out var cookie));
         job.AdviseCookie = cookie;
 


### PR DESCRIPTION
## Summary
- `BuildJob.UpdateSolution_Done` recorded terminal state but never signaled `job.Completion`, so `build.wait` always sat on its `Task.Delay(timeoutMs)` even when the build was long since done.
- Wire an `OnDone` callback from the event handler to `RpcTarget.MaybeFinalize`, which already collects diagnostics, unadvises, and completes the TCS. The event fires on the UI thread so the existing `ThrowIfNotOnUIThread` assertion holds.

Fixes #47.

## Test plan
- [ ] `build.start` on a trivial solution → `build.wait(timeoutMs: 240000)` returns within a couple seconds of the build finishing, not at 240s.
- [ ] Error-bearing build still populates `ErrorCount`/`WarningCount` and `build.errors`/`build.warnings` return the list.
- [ ] `build.cancel` still transitions cleanly (same event path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)