### PR TITLE
Add debug.stop_command and debug.kill_and_stop

### DIFF
--- a/ClaudeReadMe.md
+++ b/ClaudeReadMe.md
@@ -79,7 +79,7 @@ All tools are documented in [`DesignDoc.md §5`](./DesignDoc.md). Highlights:
 - `vs.status`, `vs.list_instances`, `vs.select`, `vs.focus` — meta / instance control
 - `solution.*`, `project.*`, `file.*`, `editor.*` — the 10% editing surface
 - `build.*` — start/cancel/wait, errors, warnings, output window
-- `debug.launch|attach|stop|continue|step_*|run_to_cursor|state` — debugger control
+- `debug.launch|attach|stop|stop_command|kill_and_stop|continue|step_*|run_to_cursor|state` — debugger control (`stop_command` and `kill_and_stop` avoid modal dialogs)
 - `bp.set|remove|list|enable|disable|set_tracepoint` — breakpoints
 - `threads.*`, `stack.*`, `frame.locals|arguments`, `eval.expression` — inspection
 - `memory.read|write`, `registers.get`, `disasm.get`, `modules.list`, `symbols.*` — native debug

--- a/DesignDoc.md
+++ b/DesignDoc.md
@@ -142,7 +142,10 @@ Edits to files that are open in VS flow through `ITextBuffer` so they participat
 ### 5.3 Debug control (M4)
 - `debug.launch({projectId?, args?, env?, cwd?, noDebug?})`
 - `debug.attach({pid? | processName?, engines?: ["managed","native","script",...]})`
-- `debug.stop()`, `debug.detach()`, `debug.restart()`
+- `debug.stop()` — DTE.Debugger.Stop; may show a modal on some VS versions
+- `debug.stop_command()` — ExecuteCommand("Debug.StopDebugging"); async, less likely to block on a dialog
+- `debug.kill_and_stop()` — kill debugged processes via Process.Kill then Stop; eliminates modal prompts
+- `debug.detach()`, `debug.restart()`
 - `debug.break_all()`, `debug.continue()`
 - `debug.step_into()`, `debug.step_over()`, `debug.step_out()`
 - `debug.run_to_cursor({file, line})`

--- a/src/VSMCP.Server/VsmcpTools.cs
+++ b/src/VSMCP.Server/VsmcpTools.cs
@@ -407,11 +407,27 @@ public sealed partial class VsmcpTools
     }
 
     [McpServerTool(Name = "debug.stop")]
-    [Description("Terminate the debuggee and return to design mode.")]
+    [Description("Terminate the debuggee via DTE.Debugger.Stop. May show a modal confirmation dialog on VS 2022+; prefer debug.stop_command or debug.kill_and_stop if that is a problem.")]
     public async Task<DebugActionResult> DebugStop(CancellationToken ct = default)
     {
         var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
         return await proxy.DebugStopAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.stop_command")]
+    [Description("Stop debugging via ExecuteCommand(\"Debug.StopDebugging\") — fires the same action as the toolbar button, which VS handles asynchronously and is less likely to block on a modal dialog.")]
+    public async Task<DebugActionResult> DebugStopCommand(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugStopCommandAsync(ct).ConfigureAwait(false);
+    }
+
+    [McpServerTool(Name = "debug.kill_and_stop")]
+    [Description("Kill all debugged processes via System.Diagnostics.Process.Kill, then call Stop. Eliminates any VS modal prompts caused by a live process. Use when debug.stop or debug.stop_command hangs on a dialog.")]
+    public async Task<DebugActionResult> DebugKillAndStop(CancellationToken ct = default)
+    {
+        var proxy = await _connection.GetOrConnectAsync(ct).ConfigureAwait(false);
+        return await proxy.DebugKillAndStopAsync(ct).ConfigureAwait(false);
     }
 
     [McpServerTool(Name = "debug.detach")]

--- a/src/VSMCP.Shared/IVsmcpRpc.cs
+++ b/src/VSMCP.Shared/IVsmcpRpc.cs
@@ -57,6 +57,8 @@ public interface IVsmcpRpc
     Task<DebugActionResult> DebugLaunchAsync(DebugLaunchOptions options, CancellationToken cancellationToken = default);
     Task<DebugActionResult> DebugAttachAsync(DebugAttachOptions options, CancellationToken cancellationToken = default);
     Task<DebugActionResult> DebugStopAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugStopCommandAsync(CancellationToken cancellationToken = default);
+    Task<DebugActionResult> DebugKillAndStopAsync(CancellationToken cancellationToken = default);
     Task<DebugActionResult> DebugDetachAsync(CancellationToken cancellationToken = default);
     Task<DebugActionResult> DebugRestartAsync(CancellationToken cancellationToken = default);
     Task<DebugActionResult> DebugBreakAllAsync(CancellationToken cancellationToken = default);

--- a/src/VSMCP.Vsix/RpcTarget.Debug.cs
+++ b/src/VSMCP.Vsix/RpcTarget.Debug.cs
@@ -106,6 +106,41 @@ internal sealed partial class RpcTarget
         return Result("Stopped.");
     }
 
+    public async Task<DebugActionResult> DebugStopCommandAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+        try { dte.ExecuteCommand("Debug.StopDebugging"); } catch (Exception ex) { throw Interop("stop_command", ex); }
+        return Result("Stop command sent.");
+    }
+
+    public async Task<DebugActionResult> DebugKillAndStopAsync(CancellationToken cancellationToken = default)
+    {
+        await _jtf.SwitchToMainThreadAsync(cancellationToken);
+        var dte = await RequireDteAsync();
+
+        // Kill all debugged processes before calling Stop so VS has nothing to prompt about.
+        var killed = new System.Collections.Generic.List<string>();
+        try
+        {
+            foreach (EnvDTE.Process proc in dte.Debugger.DebuggedProcesses)
+            {
+                try
+                {
+                    System.Diagnostics.Process.GetProcessById(proc.ProcessID).Kill();
+                    killed.Add($"{proc.Name}({proc.ProcessID})");
+                }
+                catch { }
+            }
+        }
+        catch { }
+
+        try { dte.Debugger.Stop(WaitForDesignMode: false); } catch { }
+
+        var note = killed.Count > 0 ? $"Killed: {string.Join(", ", killed)}." : "No processes to kill.";
+        return Result("Stopped.", note);
+    }
+
     public async Task<DebugActionResult> DebugDetachAsync(CancellationToken cancellationToken = default)
     {
         await _jtf.SwitchToMainThreadAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- `debug.stop` (existing) can block on a VS confirmation modal when the debuggee was launched by VS.
- `debug.stop_command` — fires `ExecuteCommand("Debug.StopDebugging")`, same as the toolbar button, handled async.
- `debug.kill_and_stop` — kills all `DebuggedProcesses` via `Process.Kill` first, then calls `Stop`; eliminates modal prompts entirely.

All three coexist so they can be tested side-by-side. Once confirmed, `debug.stop` can be replaced or delegated.

## Test plan
- [ ] `debug.stop` — confirm existing behaviour unchanged
- [ ] `debug.stop_command` — verify it stops the session; check whether the modal appears
- [ ] `debug.kill_and_stop` — verify it terminates the process and returns without a modal; `note` field should list killed process(es)

🤖 Generated with [Claude Code](https://claude.com/claude-code)