### PR TITLE
fix: file.list/search.text bare globs match by filename (+ GlobMatcher in Core)

### DIFF
--- a/src/VSMCP.Core/GlobMatcher.cs
+++ b/src/VSMCP.Core/GlobMatcher.cs
@@ -1,0 +1,65 @@
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace VSMCP.Core;
+
+/// <summary>
+/// Filesystem glob matching extracted from RpcTarget.FileDiscovery so it is unit-testable without
+/// VS. Segment semantics: <c>*</c> within a segment, <c>**</c> across segments, <c>?</c> a single
+/// non-separator char, <c>{a,b}</c> alternation. Case-insensitive; the produced regex is anchored
+/// (<c>^...$</c>).
+///
+/// <see cref="MatchesPathOrName"/> tests the pattern against the full path OR the bare file name,
+/// so a pattern like <c>*.cs</c> (no <c>**/</c>) matches files in subdirectories. This mirrors the
+/// behavior file.glob already had; file.list and search.text previously matched the full path only
+/// and so returned nothing for bare patterns like <c>*.cs</c> or <c>Foo.cs</c>.
+/// </summary>
+public static class GlobMatcher
+{
+    public static Regex ToRegex(string pattern)
+    {
+        var sb = new StringBuilder("^");
+        int i = 0;
+        while (i < pattern.Length)
+        {
+            char c = pattern[i];
+            if (c == '*')
+            {
+                if (i + 1 < pattern.Length && pattern[i + 1] == '*')
+                {
+                    sb.Append(".*");
+                    i += 2;
+                    if (i < pattern.Length && (pattern[i] == '/' || pattern[i] == '\\')) i++;
+                }
+                else { sb.Append(@"[^/\\]*"); i++; }
+            }
+            else if (c == '?') { sb.Append(@"[^/\\]"); i++; }
+            else if (c == '{')
+            {
+                int end = pattern.IndexOf('}', i);
+                if (end < 0) { sb.Append(Regex.Escape("{")); i++; continue; }
+                var alts = pattern.Substring(i + 1, end - i - 1).Split(',');
+                sb.Append('(');
+                for (int a = 0; a < alts.Length; a++)
+                {
+                    if (a > 0) sb.Append('|');
+                    sb.Append(Regex.Escape(alts[a]));
+                }
+                sb.Append(')');
+                i = end + 1;
+            }
+            else if (c == '/' || c == '\\') { sb.Append(@"[/\\]"); i++; }
+            else { sb.Append(Regex.Escape(c.ToString())); i++; }
+        }
+        sb.Append('$');
+        return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+    }
+
+    /// <summary>Match a glob against the full path OR the bare file name (so "*.cs" matches "a/b/x.cs").</summary>
+    public static bool MatchesPathOrName(string path, string pattern)
+    {
+        var rx = ToRegex(pattern);
+        return rx.IsMatch(path) || rx.IsMatch(Path.GetFileName(path));
+    }
+}

--- a/src/VSMCP.Vsix/RpcTarget.FileDiscovery.cs
+++ b/src/VSMCP.Vsix/RpcTarget.FileDiscovery.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.VisualStudio.Shell;
+using VSMCP.Core;
 using VSMCP.Shared;
 
 namespace VSMCP.Vsix;
@@ -286,49 +287,15 @@ internal sealed partial class RpcTarget
     }
 
     /// <summary>
-    /// Glob to regex with proper segment semantics: `*` within a segment, `**` across segments,
-    /// `?` single non-separator char, `{a,b}` alternation. Case-insensitive.
+    /// File-glob match against the full path OR the bare file name, so a bare pattern like "*.cs"
+    /// or "Foo.cs" (no "**/") matches files in subdirectories. Delegates to the testable
+    /// <see cref="VSMCP.Core.GlobMatcher"/> (previously matched the full path only, so file.list /
+    /// search.text returned nothing for bare patterns).
     /// </summary>
-    internal static bool MatchesGlob(string path, string pattern) => GlobToRegex(pattern).IsMatch(path);
+    internal static bool MatchesGlob(string path, string pattern) => GlobMatcher.MatchesPathOrName(path, pattern);
 
-    internal static Regex GlobToRegex(string pattern)
-    {
-        var sb = new System.Text.StringBuilder("^");
-        int i = 0;
-        while (i < pattern.Length)
-        {
-            char c = pattern[i];
-            if (c == '*')
-            {
-                if (i + 1 < pattern.Length && pattern[i + 1] == '*')
-                {
-                    sb.Append(".*");
-                    i += 2;
-                    if (i < pattern.Length && (pattern[i] == '/' || pattern[i] == '\\')) i++;
-                }
-                else { sb.Append(@"[^/\\]*"); i++; }
-            }
-            else if (c == '?') { sb.Append(@"[^/\\]"); i++; }
-            else if (c == '{')
-            {
-                int end = pattern.IndexOf('}', i);
-                if (end < 0) { sb.Append(Regex.Escape("{")); i++; continue; }
-                var alts = pattern.Substring(i + 1, end - i - 1).Split(',');
-                sb.Append('(');
-                for (int a = 0; a < alts.Length; a++)
-                {
-                    if (a > 0) sb.Append('|');
-                    sb.Append(Regex.Escape(alts[a]));
-                }
-                sb.Append(')');
-                i = end + 1;
-            }
-            else if (c == '/' || c == '\\') { sb.Append(@"[/\\]"); i++; }
-            else { sb.Append(Regex.Escape(c.ToString())); i++; }
-        }
-        sb.Append('$');
-        return new Regex(sb.ToString(), RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-    }
+    /// <summary>Glob -> anchored regex (segment-aware). Used for name matching in search.* / cpp_search.*.</summary>
+    internal static Regex GlobToRegex(string pattern) => GlobMatcher.ToRegex(pattern);
 
     public async Task<FileListResult> FileGlobAsync(
         IReadOnlyList<string> patterns, string? projectId,

--- a/tests/VSMCP.Vsix.UnitTests/GlobMatcherTests.cs
+++ b/tests/VSMCP.Vsix.UnitTests/GlobMatcherTests.cs
@@ -1,0 +1,44 @@
+using VSMCP.Core;
+using Xunit;
+
+namespace VSMCP.Tests.Vsix;
+
+/// <summary>
+/// Locks the glob semantics shared by file.list / file.glob / search.text (extracted from
+/// RpcTarget.FileDiscovery). The key fix: a bare pattern ("*.cs", "Foo.cs") matches by FILE NAME
+/// anywhere in the tree — file.list/search.text previously matched the full path only and returned
+/// empty for bare patterns.
+/// </summary>
+public class GlobMatcherTests
+{
+    [Theory]
+    // bare patterns match by file name in any subdirectory (the file.list/search.text fix)
+    [InlineData(@"P:\repo\src\sub\Foo.cs", "*.cs", true)]
+    [InlineData(@"P:\repo\src\sub\Foo.cs", "Foo.cs", true)]
+    [InlineData("src/sub/Foo.cs", "*.cs", true)]
+    [InlineData(@"P:\repo\src\sub\Foo.txt", "*.cs", false)]
+    // recursive ** crosses separators on the full path
+    [InlineData(@"P:\repo\src\Foo.cs", "**/*.cs", true)]
+    [InlineData("a/b/c/Bar.cs", "**/*.cs", true)]
+    // single * does NOT cross separators in a path-anchored pattern
+    [InlineData("a/b/Foo.cs", "a/*.cs", false)]
+    [InlineData("a/Foo.cs", "a/*.cs", true)]
+    // {alt} alternation
+    [InlineData("x/Foo.ts", "*.{ts,tsx}", true)]
+    [InlineData("x/Foo.tsx", "*.{ts,tsx}", true)]
+    [InlineData("x/Foo.cs", "*.{ts,tsx}", false)]
+    // ? single non-separator char
+    [InlineData("x/Fo.cs", "F?.cs", true)]
+    [InlineData("x/Foo.cs", "F?.cs", false)]
+    public void MatchesPathOrName_matches_expected(string path, string pattern, bool expected)
+        => Assert.Equal(expected, GlobMatcher.MatchesPathOrName(path, pattern));
+
+    [Fact]
+    public void ToRegex_is_anchored_and_case_insensitive()
+    {
+        var rx = GlobMatcher.ToRegex("*.cs");
+        Assert.Matches(rx, "Foo.CS");          // case-insensitive
+        Assert.Matches(rx, "Foo.cs");
+        Assert.DoesNotMatch(rx, "a/Foo.cs");   // anchored: bare * does not cross separators
+    }
+}


### PR DESCRIPTION
## Bug
`file.list` and `search.text` matched their glob against the **full path** only (anchored `^…$` regex), so a bare pattern like `*.cs` or `Foo.cs` (no `**/`) matched nothing for files in subdirectories — `file.list` returned empty and `search.text` (which sources files via `file.list`) found nothing. `file.glob` already worked because it also matched the bare file name. Found while running the full E2E suite (`CodeWritingSkillTests.FileList`/`SearchText` failed `Assert.NotEmpty`).

## Fix
- Extract the glob logic into a pure, testable **`VSMCP.Core.GlobMatcher`** (`ToRegex` + `MatchesPathOrName`) with **14 unit tests**.
- Route file-path matching (`MatchesGlob`, used by `file.list` → `search.text`) through `MatchesPathOrName`, so a bare pattern also matches the file name — the behavior `file.glob` already had and the tool docs' examples (`*.js`) imply.
- **Name** matching (`search.*` / `cpp_search.*` via `GlobToRegex`) is unchanged — still anchored.

## Validation
- 156 unit tests green (Server 22 + Vsix 134, incl. 14 new `GlobMatcher` cases).
- Live E2E (`VSMCP_E2E=1`): `CodeWriting` + `AuditCapabilities` = **16 passed, 0 failed, 2 intentional skips**. Fixes the `FileList`/`SearchText` failures and un-skips `FileMembers`/`FileInheritance`/`EditOrganizeUsings`.